### PR TITLE
Add keybindings for monitor up/down

### DIFF
--- a/rebuild.sh
+++ b/rebuild.sh
@@ -26,6 +26,12 @@ dconf write ${KEYS_GNOME_WM}/switch-to-workspace-left "@as []"
 # Switch to workspace right: disable <Super>Right
 dconf write ${KEYS_GNOME_WM}/switch-to-workspace-right "@as []"
 
+# Super + Ctrl + up/down, move window one monitor up/down
+# Move window one monitor down
+dconf write ${KEYS_GNOME_WM}/move-to-monitor-down "['<Primary><Shift><Super>Down','<Primary><Shift><Super>${down}']"
+# Move window one monitor up
+dconf write ${KEYS_GNOME_WM}/move-to-monitor-up "['<Primary><Shift><Super>Up','<Primary><Shift><Super>${up}']"
+
 # Super + direction keys, move window left and right monitors, or up and down workspaces
 # Move window one monitor to the left
 dconf write ${KEYS_GNOME_WM}/move-to-monitor-left "['<Shift><Super>Left','<Shift><Super>${left}']"


### PR DESCRIPTION
This adds Ctrl-Super-Shift-<up/down> keybindings to move windows up and down monitors.
I have my screens setup so that my laptop is below my external screen, and without this change
there is no way to move windows between my screens.

The keybindings are not perfectly consistent imho, but I'll add an issue with a suggestion about that.

Thanks for a great plugin! This is the only thing I really missed in Pop, and I'm very happy that you did too :)