### PR TITLE
Forest replaces AutoTiler into panel_settings.ts 

### DIFF
--- a/src/panel_settings.ts
+++ b/src/panel_settings.ts
@@ -11,7 +11,7 @@ import * as Log from 'log';
 import type { Entity } from './ecs';
 import type { Ext } from './extension';
 
-const { AutoTiler } = Me.imports.auto_tiler;
+const { AutoTiler } = Me.imports.forest;
 
 export class Indicator {
     button: any;


### PR DESCRIPTION
Make listen command reports an error with auto_tiler js module missing into panel_settings.js.
Checking the history of modifications into src *.ts file reveals that  auto_tiler module is replaced by forest.
Doing the same into panel_settings.ts removes the error and the building works correctly.