### PR TITLE
Set rebuild.sh to use bash

### DIFF
--- a/rebuild.sh
+++ b/rebuild.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/bash
 set -xe
 
 # Build and install extension


### PR DESCRIPTION
Not sure if this was left out deliberately but it helps when sh or bash isn't the active shell (e.g. fish). Open to alternatives (/usr/bin/sh).

Locally I'm running `bash ./rebuild/sh`.