### PR TITLE
fix: Add a spinbutton for the gaps entry

### DIFF
--- a/dark.css
+++ b/dark.css
@@ -24,5 +24,6 @@
 }
 
 .pop-shell-gaps-entry {
-    width: 50px;
+    /* Seems to get the width just right to fit 3 digits */
+    width: 75px;
 }

--- a/light.css
+++ b/light.css
@@ -24,5 +24,6 @@
 }
 
 .pop-shell-gaps-entry {
-    width: 50px;
+    /* Seems to get the width just right to fit 3 digits */
+    width: 75px;
 }

--- a/src/panel_settings.ts
+++ b/src/panel_settings.ts
@@ -173,6 +173,19 @@ function number_entry(
         }
     });
 
+
+    let plus_button = new St.Icon();
+    plus_button.set_icon_name('value-increase');
+    plus_button.set_icon_size(16);
+
+    let minus_button = new St.Icon();
+    minus_button.set_icon_name('value-decrease');
+    minus_button.set_icon_size(16);
+
+    // Secondary is the one on the right, primary on the left.
+    entry.set_secondary_icon(plus_button);
+    entry.set_primary_icon(minus_button);
+
     text.connect('text-changed', () => {
         const input: string = text.get_text();
         const last = input.slice(-1);

--- a/src/panel_settings.ts
+++ b/src/panel_settings.ts
@@ -177,10 +177,22 @@ function number_entry(
     let plus_button = new St.Icon();
     plus_button.set_icon_name('value-increase');
     plus_button.set_icon_size(16);
+    plus_button.connect('button-release-event', (_: any, event: any) => {
+        event.get_key_symbol();
+        let value = parseInt(text.get_text());
+        value = clamp(value + 1);
+        text.set_text(String(value));
+    })
 
     let minus_button = new St.Icon();
     minus_button.set_icon_name('value-decrease');
     minus_button.set_icon_size(16);
+    minus_button.connect('button-release-event', (_: any, event: any) => {
+        event.get_key_symbol();
+        let value = parseInt(text.get_text());
+        value = clamp(value - 1);
+        text.set_text(String(value));
+    })
 
     // Secondary is the one on the right, primary on the left.
     entry.set_secondary_icon(plus_button);

--- a/src/panel_settings.ts
+++ b/src/panel_settings.ts
@@ -177,7 +177,7 @@ function number_entry(
     let plus_button = new St.Icon();
     plus_button.set_icon_name('value-increase');
     plus_button.set_icon_size(16);
-    plus_button.connect('button-release-event', (_: any, event: any) => {
+    plus_button.connect('button-press-event', (_: any, event: any) => {
         event.get_key_symbol();
         let value = parseInt(text.get_text());
         value = clamp(value + 1);
@@ -187,7 +187,7 @@ function number_entry(
     let minus_button = new St.Icon();
     minus_button.set_icon_name('value-decrease');
     minus_button.set_icon_size(16);
-    minus_button.connect('button-release-event', (_: any, event: any) => {
+    minus_button.connect('button-press-event', (_: any, event: any) => {
         event.get_key_symbol();
         let value = parseInt(text.get_text());
         value = clamp(value - 1);


### PR DESCRIPTION
This is kind of a hack, since there aren't any spinbutton widgets available in St. Instead, this uses the primary and secondary icon properties of the St.Entry widget to add plus and minus buttons to the entry, and hooks up the `button-release-event` signal to add or subtract 1 from the value in the entry. 

The drawback to this approach is that the button layout doesn't match the Gtk.Spinbutton widget. However, since many widgets in St don't match their Gtk equivalents exactly, I don't think this is a major problem. It also doesn't appear to be possible to hold down the buttons to increase/decrease the value; it much be clicked for each change.

A benefit to doing this this way is that it doesn't require any custom widgets or theming, which reduces our maintenance burden and improves compatibility with other themes. 