### PR TITLE
build: Make depcheck less noisy.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,9 @@ convert: transpile
 	done
 
 depcheck:
-	if ! command -v tsc >/dev/null; then \
+	@echo depcheck
+	@if ! command -v tsc >/dev/null; then \
+		echo \
 		echo 'You must install TypeScript >= 3.8 to transpile: (node-typescript on Debian systems)'; \
 		exit 1; \
 	fi


### PR DESCRIPTION
Just echo a `depcheck` line when checking for the typescript
compiler instead of echoing the whole sh conditional stanza.

This reduced the visual noise every time `make` is invoked
making it easier to concentrate on the actual code transformation
and packaging.