### PR TITLE
fix: Fullscreening a window will now actually fullscreen it

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -224,7 +224,7 @@ export class Ext extends Ecs.System<ExtEvent> {
 
                     case WindowEvent.Size:
                         global.log(`Size event triggered`);
-                        if (this.auto_tiler && !win.is_maximized()) {
+                        if (this.auto_tiler && !win.is_maximized() && !win.meta.is_fullscreen()) {
                             this.auto_tiler.reflow(this, win.entity);
                         }
 


### PR DESCRIPTION
Without this, a fullscreening a window — such as when clicking the fullscreen
button in YouTube — causes the fullscreen'd window to be tiled. This is
caused by only checking for the maximization state on a size change,
when we should check both the maximization and fullscreen state.