### PR TITLE
fix: Active hint will no longer hide on workspace movements

### DIFF
--- a/src/active_hint.ts
+++ b/src/active_hint.ts
@@ -5,6 +5,7 @@ import type { Entity } from './ecs';
 import type { ShellWindow } from "./window";
 
 import * as Ecs from 'ecs';
+import * as Log from 'log';
 
 const { GLib, St } = imports.gi;
 
@@ -56,7 +57,7 @@ export class ActiveHint {
     }
 
     hide() {
-        global.log(`hiding active hint`);
+        Log.debug(`hiding active hint`);
         for (const box of this.border) {
             box.hide();
             box.visible = false;
@@ -68,6 +69,7 @@ export class ActiveHint {
     }
 
     position_changed(window: ShellWindow): void {
+        Log.debug(`active_hint: position changed`)
         if (window.is_maximized()) {
             this.hide();
         } else {
@@ -120,6 +122,7 @@ export class ActiveHint {
     }
 
     untrack() {
+        Log.debug(`active_hint: untracking window`);
         this.disconnect_signals();
 
         this.hide();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -416,10 +416,25 @@ export class Ext extends Ecs.System<ExtEvent> {
     }
 
     on_active_workspace_changed() {
-        if (this.active_hint) {
-            this.active_hint.untrack();
-        }
+        Log.debug('active workspace has changed');
 
+        const refocus_hint = () => {
+            if (!this.active_hint?.window) return
+
+            let active = this.windows.get(this.active_hint.window.entity);
+            if (!active) return;
+
+            let aws = this.workspace_id(active);
+            let cws = this.workspace_id(null);
+
+            if (aws[0] === cws[0] && aws[1] === cws[1]) {
+                this.active_hint.show();
+            } else {
+                this.active_hint.hide();
+            }
+        };
+
+        refocus_hint();
         this.exit_modes();
         this.last_focused = null;
     }


### PR DESCRIPTION
Workspace movements were causing the active hint to disappear when
migrating between an empty workspace at the bottom, and a workspace with
a window above it.