### PR TITLE
Load pop stylesheet into existing user theme

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -36,6 +36,7 @@ export interface GlobalEventTag {
 }
 
 export enum GlobalEvent {
+    GtkShellChanged,
     GtkThemeChanged,
     MonitorsChanged,
     OverviewShown,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -77,7 +77,7 @@ export class Ext extends Ecs.System<ExtEvent> {
     column_size: number = 32;
 
     /** The currently-loaded theme variant */
-    current_style: Style = this.settings.is_dark() ? Style.Dark : Style.Light;
+    current_style: Style = this.settings.is_dark_shell() ? Style.Dark : Style.Light;
 
     /** Row size in snap-to-grid */
     row_size: number = 32;
@@ -170,6 +170,10 @@ export class Ext extends Ecs.System<ExtEvent> {
 
         this.settings.int.connect('changed::gtk-theme', () => {
             this.register(Events.global(GlobalEvent.GtkThemeChanged));
+        });
+
+        this.settings.shell.connect('changed::name', () => {
+            this.register(Events.global(GlobalEvent.GtkShellChanged));
         });
     }
 
@@ -267,6 +271,10 @@ export class Ext extends Ecs.System<ExtEvent> {
             /** Stateless global events */
             case 4:
                 switch (event.event) {
+                    case GlobalEvent.GtkShellChanged:
+                        this.on_gtk_shell_changed();
+                        break;
+
                     case GlobalEvent.GtkThemeChanged:
                         this.on_gtk_theme_change();
                         break;
@@ -676,8 +684,12 @@ export class Ext extends Ecs.System<ExtEvent> {
         }
     }
 
+    on_gtk_shell_changed() {
+        this.load_theme(this.settings.is_dark_shell() ? Style.Dark : Style.Light);
+    }
+
     on_gtk_theme_change() {
-        this.load_theme(this.settings.is_dark() ? Style.Dark : Style.Light);
+        this.load_theme(this.settings.is_dark_shell() ? Style.Dark : Style.Light);
     }
 
     on_show_window_titles() {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -47,6 +47,7 @@ export class ExtensionSettings {
     ext: Settings = settings_new_schema(extension.metadata['settings-schema']);
     int: Settings = settings_new_id('org.gnome.desktop.interface');
     mutter: Settings = settings_new_id('org.gnome.mutter');
+    shell: Settings = settings_new_id('org.gnome.shell.extensions.user-theme');
 
     // Getters
 
@@ -68,6 +69,10 @@ export class ExtensionSettings {
 
     is_dark(): boolean {
         return this.int.get_string('gtk-theme').endsWith('dark');
+    }
+
+    is_dark_shell(): boolean {
+        return this.shell.get_string('name').endsWith('dark');
     }
 
     row_size(): number {


### PR DESCRIPTION
When using `loadTheme` it merges the default GNOME theme with the style sheet passed into `setThemeStylesheet`. This change instead uses the existing theme and loads the pop style sheet on top of it (if a previous theme exists).

Fixes #231 