### PR TITLE
fix: Use Gio.AppInfo.get_all for app list

### DIFF
--- a/src/app_info.ts
+++ b/src/app_info.ts
@@ -25,6 +25,7 @@ export class AppInfo {
     private generic: once_cell.OnceCell<string | null> = new OnceCell();
     private keywords_: once_cell.OnceCell<Array<string>> = new OnceCell();
     private should_show_: once_cell.OnceCell<boolean> = new OnceCell();
+    private executable_: once_cell.OnceCell<string> = new OnceCell();
 
     private name_: string;
 
@@ -48,6 +49,10 @@ export class AppInfo {
 
     exec(): string | null {
         return this.exec_.get_or_init(() => this.string("Exec"));
+    }
+
+    executable(): string {
+        return this.executable_.get_or_init(() => this.app_info.get_executable());
     }
 
     icon(): string | null {

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -75,7 +75,8 @@ export class Launcher extends search.Search {
                     || contains_pattern(info.desktop_name, needles)
                     || lib.ok(info.generic_name(), (s) => contains_pattern(s, needles))
                     || lib.ok(info.comment(), (s) => contains_pattern(s, needles))
-                    || lib.ok(info.categories(), (s) => contains_pattern(s, needles));
+                    || lib.ok(info.categories(), (s) => contains_pattern(s, needles))
+                    || lib.ok(info.executable(), (s) => contains_pattern(s, needles));
 
                 if (retain) {
                     this.selections.push(info);


### PR DESCRIPTION
- should_show and other hidden modifiers did not appear to work when loading files manually to hide from launcher
- Remove search directories
- Use [Gio.AppInfo.get_all()](https://gjs-docs.gnome.org/gio20~2.64p/gio.appinfo#function-get_all) for getting apps, should work with all installers that register with the system

fixes #293 .