### PR TITLE
fix: Destroy panel indicator disabling extension

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1355,6 +1355,11 @@ function disable() {
         ext.keybindings.disable(ext.keybindings.global)
             .disable(ext.keybindings.window_focus)
     }
+
+    if (indicator) {
+        indicator.destroy();
+        indicator = null;
+    }
 }
 
 function find_unused_workspace(): [number, any] {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1327,6 +1327,8 @@ function enable() {
         ext.register_fn(() => {
             if (ext?.auto_tiler) ext.snap_windows();
         });
+
+        ext.on_active_hint();
     }
 
     ext.signals_attach();
@@ -1349,6 +1351,10 @@ function disable() {
     if (ext) {
         ext.signals_remove();
         ext.exit_modes();
+
+        if (ext.settings.active_hint()) {
+            ext.active_hint?.untrack();
+        }
 
         layoutManager.removeChrome(ext.overlay);
 

--- a/src/panel_settings.ts
+++ b/src/panel_settings.ts
@@ -55,6 +55,10 @@ export class Indicator {
             )
         )
     }
+
+    destroy() {
+        this.button.destroy();
+    }
 }
 
 function menu_separator(text: any): any {


### PR DESCRIPTION
Tested, disabling the extension properly removes the button indicator from the panel now.

Closes pop-os/shell#259