### PR TITLE
fix: Don't unmaxize if previous window is current window

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -551,7 +551,7 @@ export class Ext extends Ecs.System<ExtEvent> {
             let prev = this.windows.get(this.prev_focused);
             let is_attached = this.auto_tiler.attached.contains(this.prev_focused);
 
-            if (prev && is_attached && prev.actor_exists() && prev.rect().contains(win.rect())) {
+            if (prev && prev !== win && is_attached && prev.actor_exists() && prev.rect().contains(win.rect())) {
                 if (prev.is_maximized()) {
                     prev.meta.unmaximize(Meta.MaximizeFlags.BOTH);
                 }
@@ -1268,7 +1268,7 @@ export class Ext extends Ecs.System<ExtEvent> {
         return entity;
     }
 
-    /// Returns the window(s) that the mouse pointer is currently hoving above.
+    /// Returns the window(s) that the mouse pointer is currently hovering above.
     * windows_at_pointer(
         cursor: Rectangle,
         monitor: number,


### PR DESCRIPTION
- Add check to see if the previous window and current window are the same
- Hovering notification causes focus change

fixes #341 