### PR TITLE
toggle_tiling keyboard shortcut

### DIFF
--- a/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
@@ -97,6 +97,12 @@
         </key>
 
         <!-- Tiling Mode -->
+        <key type="as" name="toggle-tiling">
+            <default><![CDATA[['<Super>y']]]></default>
+            <summary>Toggles a window between floating and tiling</summary>
+        </key>
+
+
         <key type="as" name="tile-move-left">
             <default><![CDATA[['Left','h']]]></default>
             <summary>Move window left</summary>

--- a/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
@@ -99,7 +99,7 @@
         <!-- Tiling Mode -->
         <key type="as" name="toggle-tiling">
             <default><![CDATA[['<Super>y']]]></default>
-            <summary>Toggles a window between floating and tiling</summary>
+            <summary>Toggles auto-tiling on and off</summary>
         </key>
 
 

--- a/src/auto_tiler.ts
+++ b/src/auto_tiler.ts
@@ -6,16 +6,16 @@ import * as log from 'log';
 import * as node from 'node';
 import * as result from 'result';
 
-import type { Entity } from 'ecs';
-import type { Ext } from 'extension';
-import type { Forest } from 'forest';
-import type { Fork } from 'fork';
-import type { Rectangle } from 'rectangle';
-import type { Result } from 'result';
-import type { ShellWindow } from 'window';
+import type {Entity} from 'ecs';
+import type {Ext} from 'extension';
+import type {Forest} from 'forest';
+import type {Fork} from 'fork';
+import type {Rectangle} from 'rectangle';
+import type {Result} from 'result';
+import type {ShellWindow} from 'window';
 
-const { Ok, Err, ERR } = result;
-const { NodeKind } = node;
+const {Ok, Err, ERR} = result;
+const {NodeKind} = node;
 const Tags = Me.imports.tags;
 
 export class AutoTiler {
@@ -28,10 +28,10 @@ export class AutoTiler {
     }
 
     /** Swap window associations in the auto-tiler
-    *
-    * Call this when a window has swapped positions with another, so that we
-    * may update the associations in the auto-tiler world.
-    */
+     *
+     * Call this when a window has swapped positions with another, so that we
+     * may update the associations in the auto-tiler world.
+     */
     attach_swap(a: Entity, b: Entity) {
         const a_ent = this.attached.remove(a);
         const b_ent = this.attached.remove(b);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -313,53 +313,6 @@ export class Ext extends Ecs.System<ExtEvent> {
     }
 
     // Extension methods
-    
-    toggle_tiling() : any {
-
-        if (this.auto_tiler) {
-            Log.info(`tile by default disabled!`);
-            this.unregister_storage(this.auto_tiler.attached);
-            this.auto_tiler = null;
-            this.settings.set_tile_by_default(false);
-        } else {
-            Log.info(`tile by default enabled!`);
-
-            const original = this.active_workspace();
-
-            let tiler = new auto_tiler.AutoTiler(
-                new Forest.Forest()
-                    .connect_on_attach((entity: Entity, window: Entity) => {
-                        tiler.attached.insert(window, entity);
-                    }),
-                this.register_storage()
-            );
-
-            this.auto_tiler = tiler;
-
-            this.settings.set_tile_by_default(true);
-
-            for (const window of this.windows.values()) {
-                if (window.is_tilable(this)) {
-                    let actor = window.meta.get_compositor_private();
-                    if (actor) {
-                        let ws = window.meta.get_workspace();
-                        if (!window.meta.minimized) {
-                            tiler.auto_tile(this, window, false);
-                        }
-
-                        if (ws === null || ws.index() !== original) {
-                            actor.hide()
-                        } else {
-                            actor.show();
-                        }
-                    }
-                }
-            }
-
-            this.register_fn(() => this.switch_to_workspace(original));
-        }
-    }
-
 
     activate_window(window: Window.ShellWindow | null) {
         if (window) {
@@ -1201,6 +1154,51 @@ export class Ext extends Ecs.System<ExtEvent> {
             if (this.contains_tag(entity, Tags.Tiled)) {
                 yield entity;
             }
+        }
+    }
+
+    toggle_tiling() : any {
+        if (this.auto_tiler) {
+            Log.info(`tile by default disabled!`);
+            this.unregister_storage(this.auto_tiler.attached);
+            this.auto_tiler = null;
+            this.settings.set_tile_by_default(false);
+        } else {
+            Log.info(`tile by default enabled!`);
+
+            const original = this.active_workspace();
+
+            let tiler = new auto_tiler.AutoTiler(
+                new Forest.Forest()
+                    .connect_on_attach((entity: Entity, window: Entity) => {
+                        tiler.attached.insert(window, entity);
+                    }),
+                this.register_storage()
+            );
+
+            this.auto_tiler = tiler;
+
+            this.settings.set_tile_by_default(true);
+
+            for (const window of this.windows.values()) {
+                if (window.is_tilable(this)) {
+                    let actor = window.meta.get_compositor_private();
+                    if (actor) {
+                        let ws = window.meta.get_workspace();
+                        if (!window.meta.minimized) {
+                            tiler.auto_tile(this, window, false);
+                        }
+
+                        if (ws === null || ws.index() !== original) {
+                            actor.hide()
+                        } else {
+                            actor.show();
+                        }
+                    }
+                }
+            }
+
+            this.register_fn(() => this.switch_to_workspace(original));
         }
     }
 

--- a/src/keybindings.ts
+++ b/src/keybindings.ts
@@ -26,7 +26,8 @@ export class Keybindings {
             "focus-up": () => ext.activate_window(ext.focus_selector.up(ext, null)),
             "focus-right": () => ext.activate_window(ext.focus_selector.right(ext, null)),
             "tile-orientation": () => ext.auto_tiler?.toggle_orientation(ext),
-            "toggle-floating": () => ext.auto_tiler?.toggle_floating(ext)
+            "toggle-floating": () => ext.auto_tiler?.toggle_floating(ext),
+            "toggle-tiling": () => ext.toggle_tiling(),
         };
     }
 
@@ -51,4 +52,4 @@ export class Keybindings {
 
         return this;
     }
-};
+}

--- a/src/panel_settings.ts
+++ b/src/panel_settings.ts
@@ -1,15 +1,14 @@
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 
-import * as auto_tiler from 'auto_tiler';
+// import * as auto_tiler from 'auto_tiler';
 import * as Log from 'log';
 
-import type { Entity } from './ecs';
+//import type { Entity } from './ecs';
 import type { Ext } from './extension';
 
 const { Clutter, Gio, St } = imports.gi;
 const { PopupBaseMenuItem, PopupMenuItem, PopupSwitchMenuItem, PopupSeparatorMenuItem } = imports.ui.popupMenu;
 const { Button } = imports.ui.panelMenu;
-const { Forest } = Me.imports.forest;
 const GLib: GLib = imports.gi.GLib;
 
 export class Indicator {
@@ -233,49 +232,7 @@ function toggle(desc: string, active: boolean, connect: (toggle: any) => void): 
     return toggle;
 }
 
+
 function tiled(ext: Ext): any {
-    return toggle(_("Tile Windows"), null != ext.auto_tiler, () => {
-        if (ext.auto_tiler) {
-            Log.info(`tile by default disabled`);
-            ext.unregister_storage(ext.auto_tiler.attached);
-            ext.auto_tiler = null;
-            ext.settings.set_tile_by_default(false);
-        } else {
-            Log.info(`tile by default enabled`);
-
-            const original = ext.active_workspace();
-
-            let tiler = new auto_tiler.AutoTiler(
-                new Forest()
-                    .connect_on_attach((entity: Entity, window: Entity) => {
-                        tiler.attached.insert(window, entity);
-                    }),
-                ext.register_storage()
-            );
-
-            ext.auto_tiler = tiler;
-
-            ext.settings.set_tile_by_default(true);
-
-            for (const window of ext.windows.values()) {
-                if (window.is_tilable(ext)) {
-                    let actor = window.meta.get_compositor_private();
-                    if (actor) {
-                        let ws = window.meta.get_workspace();
-                        if (!window.meta.minimized) {
-                            tiler.auto_tile(ext, window, false);
-                        }
-
-                        if (ws === null || ws.index() !== original) {
-                            actor.hide()
-                        } else {
-                            actor.show();
-                        }
-                    }
-                }
-            }
-
-            ext.register_fn(() => ext.switch_to_workspace(original));
-        }
-    });
+    return toggle(_("Tile Windows"), null != ext.auto_tiler, () => ext.toggle_tiling());
 }


### PR DESCRIPTION
Added a new keyboard short cut 'toggle-tiling'.
to do this, added method toggle_tiling to Extension. 
This new method is a relocation of the toggle code from panel_settings.
I have used Super-Y as the default shortcut because it was the first key I thought of that didn't seem to be mapped already. 

Warning. This is the first time I have used typescript, and it's the most Javascript I've done in five years.