### PR TITLE
Spaces are now trimmed from beginning and end of search request

### DIFF
--- a/src/search.ts
+++ b/src/search.ts
@@ -61,7 +61,7 @@ export class Search {
         this.text.connect("text-changed", (entry: any) => {
             this.clear();
 
-            const text = (entry as Clutter.Text).get_text();
+            const text = (entry as Clutter.Text).get_text().trim();
 
             let prefix = this.has_prefix(text);
             mode(prefix);


### PR DESCRIPTION
Previously you couldn't use extension prefixes("=","d:", etc) if you accidentally put a space before them. Also solves issue with putting a space at the beginning of a normal search query.