### PR TITLE
Update the toggle switch in the panel based on the keyboard event.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -120,6 +120,8 @@ export class Ext extends Ecs.System<ExtEvent> {
 
     tween_signals: Map<string, [SignalID, any]> = new Map();
 
+    tiling_toggle_switch: any | null = null;  /** reference to the PopupSwitchMenuItem menu item, so state can be toggled */
+
     /** Initially set to true when the extension is initializing */
     init: boolean = true;
 
@@ -1148,6 +1150,7 @@ export class Ext extends Ecs.System<ExtEvent> {
             this.unregister_storage(this.auto_tiler.attached);
             this.auto_tiler = null;
             this.settings.set_tile_by_default(false);
+            this.tiling_toggle_switch._switch.state = false;
         } else {
             Log.info(`tile by default enabled!`);
 
@@ -1164,6 +1167,7 @@ export class Ext extends Ecs.System<ExtEvent> {
             this.auto_tiler = tiler;
 
             this.settings.set_tile_by_default(true);
+            this.tiling_toggle_switch._switch.state = true;
 
             for (const window of this.windows.values()) {
                 if (window.is_tilable(this)) {

--- a/src/panel_settings.ts
+++ b/src/panel_settings.ts
@@ -236,7 +236,8 @@ function toggle(desc: string, active: boolean, connect: (toggle: any) => void): 
     return toggle;
 }
 
-
 function tiled(ext: Ext): any {
-    return toggle(_("Tile Windows"), null != ext.auto_tiler, () => ext.toggle_tiling());
+    let t = toggle(_("Tile Windows"), null != ext.auto_tiler, () => ext.toggle_tiling());
+    ext.tiling_toggle_switch = t;  // property _switch is the actual UI element
+    return t;
 }


### PR DESCRIPTION
This is to toggle the auto-tile switch when the keyboard shortcut is invoked. I am completely new to gnome shell extensions so if there is a better way to do this (with signals?) then please tell me.
It does however seem to work. 