### PR TITLE
fix: do not add active_hint for windows with skip_taskbar

### DIFF
--- a/src/active_hint.ts
+++ b/src/active_hint.ts
@@ -92,6 +92,8 @@ export class ActiveHint {
 
             this.untrack();
         }
+        
+        if (window.meta.is_skip_taskbar()) return
 
         const actor = window.meta.get_compositor_private();
         if (!actor) return;


### PR DESCRIPTION
Windows with state `skip_bar` should not get the `active_hint`.

This resolves issues with launchers like ulauncher, or terminal dropdowns like guake. 