### PR TITLE
Blacklist Kotatogram's mediaviewer window from being tilable

### DIFF
--- a/src/window.ts
+++ b/src/window.ts
@@ -270,7 +270,8 @@ export function activate(win: Meta.Window) {
 export function blacklisted(window_class: string, title: string): boolean {
     return BLACKLIST.indexOf(window_class) > -1
         || (window_class === "Steam" && title !== "Steam")
-        || (window_class === "TelegramDesktop" && title === "Media viewer");
+        || (window_class === "TelegramDesktop" && title === "Media viewer")
+        || (window_class === "KotatogramDesktop" && title === "Media viewer");
 }
 
 export function place_pointer_on(win: Meta.Window) {


### PR DESCRIPTION
This pull request will blacklist Kotatogram Desktop's image viewer window from being tilable.

Kotatogram is a fork of Telegram Desktop, which already appears in the blacklist