### PR TITLE
Add JetBrains Toolbox to blacklist

### DIFF
--- a/src/window.ts
+++ b/src/window.ts
@@ -258,7 +258,8 @@ const BLACKLIST: string[] = [
     'Conky',
     'Com.github.donadigo.eddy',
     'Gnome-screenshot',
-    'Authy Desktop'
+    'Authy Desktop',
+    'jetbrains-toolbox'
 ];
 
 /// Activates a window, and moves the mouse point to the center of it.


### PR DESCRIPTION
JetBrains Toolbox doesn't tile well and the window acts more like a dropdown for the taskbar.