### PR TITLE
fix(autotiler): handle minimize on_grab_end

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -675,6 +675,11 @@ export class Ext extends Ecs.System<ExtEvent> {
 
         this.size_signals_unblock(win);
 
+        if (win.meta && win.meta.minimized) {
+            this.on_minimize(win);
+            return;
+        }
+
         if (win.is_maximized()) {
             return;
         }


### PR DESCRIPTION
Update 1: Also checked #346
***
Fixes for #309, #411 and not sure on #237.

Tested these apps (can replicate and then are now fixed):
- Terminator
- Discord
- MS Teams Preview
- Spotify
- Slack

Electron apps or some apps that manage their own window title bars do not
send minimize events, but rather PopOS shell treats them as a grab event.

When `on_grab_end` event is  sent by these apps and the meta.minimized
attribute is set, re-using the default `extension->on_minimize()` handler should fix the empty space being left by these types of apps. Which should properly cleanup and call the `autotiler -> detach_window()` function.