### PR TITLE
fix(autotiler): do not show when minimize

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1198,13 +1198,8 @@ export class Ext extends Ecs.System<ExtEvent> {
                 if (window.is_tilable(this)) {
                     let actor = window.meta.get_compositor_private();
                     if (actor) {
-                        let ws = window.meta.get_workspace();
                         if (!window.meta.minimized) {
                             tiler.auto_tile(this, window, false);
-                        }
-
-                        if (ws === null || ws.index() !== original) {
-                            actor.hide()
                         }
                     }
                 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1205,8 +1205,6 @@ export class Ext extends Ecs.System<ExtEvent> {
 
                         if (ws === null || ws.index() !== original) {
                             actor.hide()
-                        } else {
-                            actor.show();
                         }
                     }
                 }


### PR DESCRIPTION
Update 1: Removed the entire actor.hide() and actor.show() blocks. If not removing the actor.hide(), the dash to dock no longer shows even when moving the mouse at the edges. It seems they were meant to work in tandem.

Perhaps replace the actor.hide()/actor.show() by a different event mechanism.

***
Fixes #393

It seems like the Clutter.Actor utility is messing up the display when re-enabling tiling. It tries to show the minimized applications when it should not be. (I guess a question to the PopOS Shell devs if it is indeed required to re-tile minimized apps).

It shows an un-clickable window behind unless maximized or re-engaged minimize.
The fix seems to work well on Super + D (or hide all windows)