### PR TITLE
Add page up and down hotkeys

### DIFF
--- a/rebuild.sh
+++ b/rebuild.sh
@@ -45,17 +45,17 @@ dconf write ${KEYS_GNOME_WM}/switch-to-workspace-right "@as []"
 # Move window one monitor to the left
 dconf write ${KEYS_GNOME_WM}/move-to-monitor-left "['<Shift><Super>Left','<Shift><Super>${left}']"
 # Move window one workspace down
-dconf write ${KEYS_GNOME_WM}/move-to-workspace-down "['<Shift><Super>Down','<Shift><Super>${down}']"
+dconf write ${KEYS_GNOME_WM}/move-to-workspace-down "['<Shift><Super>Down','<Shift><Super>${down}','<Shift><Super>Page_Down']"
 # Move window one workspace up
-dconf write ${KEYS_GNOME_WM}/move-to-workspace-up "['<Shift><Super>Up','<Shift><Super>${up}']"
+dconf write ${KEYS_GNOME_WM}/move-to-workspace-up "['<Shift><Super>Up','<Shift><Super>${up}','<Shift><Super>Page_Up']"
 # Move window one monitor to the right
 dconf write ${KEYS_GNOME_WM}/move-to-monitor-right "['<Shift><Super>Right','<Shift><Super>${right}']"
 
 # Super + Ctrl + direction keys, change workspaces, move focus between monitors
 # Move to workspace below
-dconf write ${KEYS_GNOME_WM}/switch-to-workspace-down "['<Primary><Super>Down','<Primary><Super>${down}']"
+dconf write ${KEYS_GNOME_WM}/switch-to-workspace-down "['<Primary><Super>Down','<Primary><Super>${down}','<Super>Page_Down']"
 # Move to workspace above
-dconf write ${KEYS_GNOME_WM}/switch-to-workspace-up "['<Primary><Super>Up','<Primary><Super>${up}']"
+dconf write ${KEYS_GNOME_WM}/switch-to-workspace-up "['<Primary><Super>Up','<Primary><Super>${up}','<Super>Page_Up']"
 
 # Disable tiling to left / right of screen
 dconf write ${KEYS_MUTTER}/toggle-tiled-left "@as []"


### PR DESCRIPTION
Add hotkeys for paging up and down as this is the default hotkey for gnome.
Adding these hotkeys would make it easier for people who are used to the normal way workspaces work in gnome.