### PR TITLE
Fix closed applications dash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ debian/*
 !debian/copyright
 !debian/rules
 .confirm_shortcut_change
+.vscode

--- a/src/forest.ts
+++ b/src/forest.ts
@@ -75,7 +75,11 @@ export class Forest extends Ecs.World {
             const window = ext.windows.get(entity);
             if (!window) continue;
 
-            window.meta.change_workspace_by_index(workspace, false);
+            
+            if (workspace) { 
+                // do nothing for now
+                // window.meta.change_workspace_by_index(workspace, false);
+            }
 
             move_window(ext, window, r.rect, () => { });
         }


### PR DESCRIPTION
Was still reproducible on #405. This additional change fixes #220.

Test case 1 (happens only on Tiling Mode):
1. Click icon Files on Dash to Dock
2. Right-click New Window from Dock.
3. Focus on one of the Files window, CTRL+Q
4. Should not leave any window dots on Dock.

Test Case 2 (happens only in Tiling Mode):
1. Toggle Title Bar on Firefox Customize page.

This is probably a question to PopShell devs on what this call is for:
```
// window.meta.change_workspace_by_index(workspace, false);
```
If this is disabled, the closing of apps via CTRL+Q does not leave any ghost dots in Dash to Dock nor toggle of Firefox's Title Bar in Customize.