### PR TITLE
Rename 'search' to 'activate-launcher' in schema

### DIFF
--- a/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
@@ -65,7 +65,7 @@
         </key>
 
         <!-- Launcher -->
-        <key type="as" name="search">
+        <key type="as" name="activate-launcher">
             <default><![CDATA[['<Super>slash']]]></default>
             <summary>Search key combo</summary>
         </key>

--- a/src/keybindings.ts
+++ b/src/keybindings.ts
@@ -12,7 +12,7 @@ export class Keybindings {
     constructor(ext: Ext) {
         this.ext = ext;
         this.global = {
-            "search": () => {
+            "activate-launcher": () => {
                 ext.tiler.exit(ext);
                 ext.window_search.load_desktop_files();
                 ext.window_search.open(ext);


### PR DESCRIPTION
This name collided with another key binding, causing problems in gnome-control-center.This is probably a clearer name anyway.

Combined with the corresponding name change in `gnome-control-center`, this fixes https://github.com/pop-os/gnome-control-center/issues/93.

Corresponding Control Center PR: https://github.com/pop-os/gnome-control-center/pull/99.