### PR TITLE
feat(window): remove window hints via Gdk

### DIFF
--- a/src/auto_tiler.ts
+++ b/src/auto_tiler.ts
@@ -139,7 +139,8 @@ export class AutoTiler {
     detach_window(ext: Ext, win: Entity) {
         this.attached.take_with(win, (prev_fork: Entity) => {
             const reflow_fork = this.forest.detach(prev_fork, win);
-
+            const meta = ext.windows.get(win)
+            meta?.restore_window_hints()
             if (reflow_fork) {
                 const fork = reflow_fork[1];
                 this.tile(ext, fork, fork.area);


### PR DESCRIPTION
There seems to be an API to adjust the window hints via GDK11. Looking for feedback @mmstick.

**Experiment**: change hints on tile, remove hints on detach. There has to be a decision on what is the smallest possible window to view, versus just splitting them all like i3?

**What works:**

- To users who want (the thrill) to resize the windows to as much as it can. Not sure who likes a 20 x 60 window.
- This makes it possible for pop-shell to control some boundaries on the size of some windows. #447 
- Edit Win Mode (`Super + Enter`), can now squeeze some windows.

**Issues:** 

- The shell responds slowly on closing windows.
- Dragging and dropping window edges using mouse is glitchy.
- During `Alt + F2, r` on windows that glitched will be closed by gnome-shell.