### PR TITLE
fix(wm-hints): override/restore

### DIFF
--- a/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
@@ -169,5 +169,10 @@
             <default><![CDATA[['<Primary>Right','<Primary>l']]]></default>
             <summary>Swap window right</summary>
         </key>
+
+        <key type="b" name="override-wm-hints">
+            <default>false</default>
+            <summary>Experimental: Override the Window Hints for better sizing calculations</summary>
+        </key>
     </schema>
 </schemalist>

--- a/src/auto_tiler.ts
+++ b/src/auto_tiler.ts
@@ -139,7 +139,8 @@ export class AutoTiler {
     detach_window(ext: Ext, win: Entity) {
         this.attached.take_with(win, (prev_fork: Entity) => {
             const reflow_fork = this.forest.detach(prev_fork, win);
-
+            const meta = ext.windows.get(win)
+            meta?.restore_window_hints()
             if (reflow_fork) {
                 const fork = reflow_fork[1];
                 this.tile(ext, fork, fork.area);

--- a/src/auto_tiler.ts
+++ b/src/auto_tiler.ts
@@ -126,7 +126,7 @@ export class AutoTiler {
      * - Then tries to tile onto a monitor
      */
     auto_tile(ext: Ext, win: ShellWindow, ignore_focus: boolean = false) {
-        win.change_window_hints();
+        // win.change_window_hints();
         const result = this.fetch_mode(ext, win, ignore_focus);
         this.detach_window(ext, win.entity);
         if (result.kind == ERR) {

--- a/src/auto_tiler.ts
+++ b/src/auto_tiler.ts
@@ -126,6 +126,7 @@ export class AutoTiler {
      * - Then tries to tile onto a monitor
      */
     auto_tile(ext: Ext, win: ShellWindow, ignore_focus: boolean = false) {
+        win.change_window_hints();
         const result = this.fetch_mode(ext, win, ignore_focus);
         this.detach_window(ext, win.entity);
         if (result.kind == ERR) {

--- a/src/auto_tiler.ts
+++ b/src/auto_tiler.ts
@@ -139,8 +139,6 @@ export class AutoTiler {
     detach_window(ext: Ext, win: Entity) {
         this.attached.take_with(win, (prev_fork: Entity) => {
             const reflow_fork = this.forest.detach(prev_fork, win);
-            const meta = ext.windows.get(win)
-            meta?.restore_window_hints()
             if (reflow_fork) {
                 const fork = reflow_fork[1];
                 this.tile(ext, fork, fork.area);
@@ -247,12 +245,18 @@ export class AutoTiler {
         if (ext.contains_tag(focused.entity, Tags.Floating)) {
             ext.delete_tag(focused.entity, Tags.Floating);
             this.auto_tile(ext, focused, false);
+
+            // Modify WM hints so we can demand sizes
+            focused.change_window_hints();
         } else {
             const fork_entity = this.attached.get(focused.entity);
             if (fork_entity) {
                 this.detach_window(ext, focused.entity);
                 ext.add_tag(focused.entity, Tags.Floating);
             }
+
+            // Restore WM hints before it was tiled
+            focused.restore_window_hints();
         }
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -739,7 +739,7 @@ export class Ext extends Ecs.System<ExtEvent> {
         if (!win) return;
 
         if (win.is_tilable(this)) {
-            win.restore_window_hints();
+            // win.restore_window_hints();
 
             let entity = win.entity;
             let rect = win.rect();

--- a/src/forest.ts
+++ b/src/forest.ts
@@ -684,11 +684,12 @@ function move_window(ext: Ext, window: ShellWindow, rect: Rectangular, on_comple
     const actor = window.meta.get_compositor_private();
 
     if (!actor) {
-        Log.warn(`Window(${window.entity}) does not have an actor, and therefore cannot be moved`);
+        Log.warn(`Window(${window.meta.get_title()}) does not have an actor, and therefore cannot be moved`);
         return;
     }
 
     ext.size_signals_block(window);
+
     window.move(ext, rect, () => {
         on_complete();
         ext.size_signals_unblock(window);

--- a/src/panel_settings.ts
+++ b/src/panel_settings.ts
@@ -22,15 +22,15 @@ export class Indicator {
         ext.button_gio_icon_auto_off = Gio.icon_new_for_string(`${Me.path}/icons/pop-shell-auto-off-symbolic.svg`);
 
         let button_icon_auto_on = new St.Icon({
-            gicon: ext.button_gio_icon_auto_on ,
+            gicon: ext.button_gio_icon_auto_on,
             style_class: "system-status-icon",
         });
         let button_icon_auto_off = new St.Icon({
-            gicon:  ext.button_gio_icon_auto_off,
+            gicon: ext.button_gio_icon_auto_off,
             style_class: "system-status-icon",
         });
 
-        if (ext.settings.tile_by_default()){
+        if (ext.settings.tile_by_default()) {
             this.button.icon = button_icon_auto_on;
         } else {
             this.button.icon = button_icon_auto_off;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -52,6 +52,7 @@ const ROW_SIZE = 'row-size';
 const SHOW_TITLE = 'show-title';
 const SNAP_TO_GRID = 'snap-to-grid';
 const TILE_BY_DEFAULT = 'tile-by-default';
+const OVERRIDE_WM_HINTS = 'override-wm-hints';
 
 export class ExtensionSettings {
     ext: Settings = settings_new_schema(extension.metadata['settings-schema']);
@@ -116,6 +117,10 @@ export class ExtensionSettings {
             : false;
     }
 
+    override_wm_hints(): boolean {
+        return this.ext.get_boolean(OVERRIDE_WM_HINTS);
+    }
+
     // Setters
 
     set_active_hint(set: boolean) {
@@ -148,5 +153,9 @@ export class ExtensionSettings {
 
     set_tile_by_default(set: boolean) {
         this.ext.set_boolean(TILE_BY_DEFAULT, set);
+    }
+
+    set_override_wm_hints(set: boolean) {
+        this.ext.set_boolean(OVERRIDE_WM_HINTS, set);
     }
 }

--- a/src/tiling.ts
+++ b/src/tiling.ts
@@ -8,6 +8,7 @@ import * as Rect from 'rectangle';
 import * as window from 'window';
 import * as shell from 'shell';
 import * as Tweener from 'tweener';
+import * as Events from 'events';
 
 import type { Entity } from './ecs';
 import type { Rectangle } from './rectangle';
@@ -15,6 +16,7 @@ import type { Ext } from './extension';
 import { AutoTiler } from './auto_tiler';
 
 const { Meta } = imports.gi;
+const { WindowEvent } = Events;
 const Main = imports.ui.main;
 const { ShellWindow } = window;
 
@@ -211,6 +213,10 @@ export class Tiler {
 
                     (ext.auto_tiler as AutoTiler).forest.resize(ext, entity, fork, (this.window as Entity), grab_op.operation(crect), crect);
                     grab_op.rect = crect.clone();
+
+                    // send a resize event so that the window edit will work for some apps who resets back the WM_HINTS, 
+                    // e.g.Gnome Settings. Since the change hints is in the window.arrange()
+                    ext.register(Events.window_event(window, WindowEvent.Size));
                 };
 
                 resize(mov1, callback);

--- a/src/window.ts
+++ b/src/window.ts
@@ -21,6 +21,8 @@ const { OnceCell } = once_cell;
 
 export var window_tracker = Shell.WindowTracker.get_default();
 
+const GDK_DISPLAY = Gdk.DisplayManager.get().get_default_display();
+
 const WM_TITLE_BLACKLIST: Array<string> = [
     'Firefox',
     'Nightly', // Firefox Nightly
@@ -263,12 +265,11 @@ export class ShellWindow {
         })
     }
 
-    gdk_window() {
-        const display = Gdk.DisplayManager.get().get_default_display();
-        return GdkX11.X11Window.foreign_new_for_display(display, this.xid())
+    gdk_window(): any {
+        return GdkX11.X11Window.foreign_new_for_display(GDK_DISPLAY, this.xid())
     }
 
-    change_window_hints() { 
+    change_window_hints(): void {
         let gdk_window = this.gdk_window()
         let geo = new Gdk.Geometry()
         geo.min_height = -1;
@@ -276,7 +277,7 @@ export class ShellWindow {
         gdk_window.set_geometry_hints(geo, Gdk.WindowHints.MIN_SIZE);
     }
 
-    restore_window_hints() {
+    restore_window_hints(): void {
         let gdk_window = this.gdk_window()
         let geo = new Gdk.Geometry()
         gdk_window.set_geometry_hints(geo, 0);

--- a/src/window.ts
+++ b/src/window.ts
@@ -164,8 +164,6 @@ export class ShellWindow {
         const clone = Rect.Rectangle.from_meta(rect);
         const actor = this.meta.get_compositor_private();
 
-        this.change_window_hints()
-
         if (actor) {
             this.meta.unmaximize(Meta.MaximizeFlags.HORIZONTAL);
             this.meta.unmaximize(Meta.MaximizeFlags.VERTICAL);

--- a/src/window.ts
+++ b/src/window.ts
@@ -15,7 +15,7 @@ import type { Ext } from './extension';
 import type { Rectangle } from './rectangle';
 
 // const GLib: GLib = imports.gi.GLib;
-const { Gdk, Meta, Shell, St } = imports.gi;
+const { Gdk, GdkX11, Meta, Shell, St } = imports.gi;
 
 const { OnceCell } = once_cell;
 
@@ -161,6 +161,9 @@ export class ShellWindow {
     move(ext: Ext, rect: Rectangular, on_complete?: () => void) {
         const clone = Rect.Rectangle.from_meta(rect);
         const actor = this.meta.get_compositor_private();
+
+        this.change_window_hints()
+
         if (actor) {
             this.meta.unmaximize(Meta.MaximizeFlags.HORIZONTAL);
             this.meta.unmaximize(Meta.MaximizeFlags.VERTICAL);
@@ -258,6 +261,25 @@ export class ShellWindow {
             if (utils.is_wayland()) return null;
             return xprop.get_xid(this.meta);
         })
+    }
+
+    gdk_window() {
+        const display = Gdk.DisplayManager.get().get_default_display();
+        return GdkX11.X11Window.foreign_new_for_display(display, this.xid())
+    }
+
+    change_window_hints() { 
+        let gdk_window = this.gdk_window()
+        let geo = new Gdk.Geometry()
+        geo.min_height = -1;
+        geo.min_width = -1;
+        gdk_window.set_geometry_hints(geo, Gdk.WindowHints.MIN_SIZE);
+    }
+
+    restore_window_hints() {
+        let gdk_window = this.gdk_window()
+        let geo = new Gdk.Geometry()
+        gdk_window.set_geometry_hints(geo, 0);
     }
 }
 


### PR DESCRIPTION
**Summary:** 

- Fixes #447, #85  - used the xprop `WM_NORMAL_HINTS` value and set them using `Gdk.Window.set_geometry_hints()`.
- Updated how the BASE, RESIZE INCREMENT and SIZE are obtained from `xprop` helper method.

**Issues**:

- (FIXED) Mouse `drag-resize` an active `Gnome Terminal` window with overriden hints are glitchy. E.g. apps that has all 3 attributes specified on WM_NORMAL_HINTS: base dimensions, increment size, minimum size dimensions.
- Tabbed `Gnome Terminal` (a Terminal Window embedded on its Terminal Screen) does not change back the window hints during drag-resize. Individual Gnome Terminal Windows (detached tab or normal) windows _work_ properly
- Applications crashing on `gnome-shell` restart (`Alt+F2, r`). E.g. some electron apps like VS Code, PyGObject apps. **Note:** _Dash-To-Dock_ also closes some apps when it is disabled - for comparison.
- Gnome control center when on right-hand-size of monitor edge, and too small for when child panel opens (network, bluetooth), moves to the next monitor on the right. It triggers a resize, and pop-shell sees it on the that next monitor then captures and re-arrange. When GCC, left side _works_ fine.