### PR TITLE
Collection of fixes from the stacking branch

### DIFF
--- a/src/auto_tiler.ts
+++ b/src/auto_tiler.ts
@@ -255,8 +255,8 @@ export class AutoTiler {
         }
     }
 
-    toggle_orientation(ext: Ext) {
-        const result = this.toggle_orientation_(ext);
+    toggle_orientation(ext: Ext, window: ShellWindow) {
+        const result = this.toggle_orientation_(ext, window);
         if (result.kind == ERR) {
             log.warn(`toggle_orientation: ${result.value}`);
         } else {
@@ -316,12 +316,7 @@ export class AutoTiler {
         log.info('\n\n' + buf);
     }
 
-    private toggle_orientation_(ext: Ext): Result<void, string> {
-        const focused = ext.focus_window();
-        if (!focused) {
-            return Err('no focused window to toggle');
-        }
-
+    private toggle_orientation_(ext: Ext, focused: ShellWindow): Result<void, string> {
         if (focused.meta.get_maximized()) {
             return Err('cannot toggle maximized window');
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -222,6 +222,8 @@ export class Ext extends Ecs.System<ExtEvent> {
                         return;
                     }
 
+                    actor.remove_all_transitions();
+
                     event.window.meta.move_resize_frame(
                         true,
                         event.kind.rect.x,

--- a/src/forest.ts
+++ b/src/forest.ts
@@ -75,7 +75,15 @@ export class Forest extends Ecs.World {
             const window = ext.windows.get(entity);
             if (!window) continue;
 
-            move_window(ext, window, r.rect, () => { });
+            let on_complete = () => { }
+            if (ext.tiler.window) {
+                if (Ecs.entity_eq(ext.tiler.window, entity)) {
+                    on_complete = () => {
+                        ext.set_overlay(window.rect());
+                    }
+                }
+            }
+            move_window(ext, window, r.rect, on_complete);
         }
 
         this.requested.clear();

--- a/src/fork.ts
+++ b/src/fork.ts
@@ -34,6 +34,9 @@ export class Fork {
     orientation_changed: boolean = false;
     is_toplevel: boolean = false;
 
+    /** Tracks toggle count so that we may swap branches when toggled twice */
+    private n_toggled: number = 0;
+
     constructor(entity: Entity, left: Node, right: Node | null, area: Rectangle, workspace: number, orient: Lib.Orientation) {
         this.area = area;
         this.left = left;
@@ -222,5 +225,15 @@ export class Fork {
             : Lib.Orientation.HORIZONTAL;
 
         this.orientation_changed = true;
+        if (this.n_toggled === 1) {
+            if (this.right) {
+                const tmp = this.right;
+                this.right = this.left;
+                this.left = tmp;
+            }
+            this.n_toggled = 0;
+        } else {
+            this.n_toggled += 1;
+        }
     }
 }

--- a/src/keybindings.ts
+++ b/src/keybindings.ts
@@ -25,7 +25,10 @@ export class Keybindings {
             "focus-down": () => ext.activate_window(ext.focus_selector.down(ext, null)),
             "focus-up": () => ext.activate_window(ext.focus_selector.up(ext, null)),
             "focus-right": () => ext.activate_window(ext.focus_selector.right(ext, null)),
-            "tile-orientation": () => ext.auto_tiler?.toggle_orientation(ext),
+            "tile-orientation": () => {
+                const win = ext.focus_window();
+                if (win) ext.auto_tiler?.toggle_orientation(ext, win);
+            },
             "toggle-floating": () => ext.auto_tiler?.toggle_floating(ext),
             "toggle-tiling": () => ext.toggle_tiling(),
         };

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -157,7 +157,7 @@ export class Launcher extends search.Search {
             if (id >= this.selections.length) return;
 
             const selected = this.selections[id];
-            if (selected instanceof window.ShellWindow) {
+            if (selected && selected instanceof window.ShellWindow) {
                 if (selected.workspace_id() == ext.active_workspace()) {
                     const rect = selected.rect();
                     ext.overlay.x = rect.x
@@ -187,7 +187,6 @@ export class Launcher extends search.Search {
             }
 
             const launcher = MODES[this.mode].init(ext, this);
-            log.info(`Launcher Mode: "${launcher.prefix}"`);
             return launcher.apply(text.slice(launcher.prefix.length).trim(), index);
         };
 
@@ -210,7 +209,6 @@ export class Launcher extends search.Search {
                 for (const result of app_info.load_desktop_entries(path)) {
                     if (result.kind == OK) {
                         const value = result.value;
-                        log.info(value.display());
                         this.desktop_apps.push([where, value]);
                     } else {
                         const why = result.value;

--- a/src/log.ts
+++ b/src/log.ts
@@ -9,10 +9,7 @@ export function info(text: string) {
 }
 
 export function error(text: string) {
-    if (log_level > 1) {
-        log("[ERROR] " + text);
-        global.notify_error("Pop Shell Error", text);
-    };
+    if (log_level > 1) log("[ERROR] " + text);
 }
 
 export function warn(text: string) {

--- a/src/mod.d.ts
+++ b/src/mod.d.ts
@@ -25,7 +25,7 @@ declare interface GLib {
 
     spawn_command_line_sync(cmd: string): ProcessResult;
 
-    timeout_add(ms: number, priority: any, callback: () => Boolean): number;
+    timeout_add(priority: any, ms: number, callback: () => Boolean): number;
 }
 
 declare namespace GObject {

--- a/src/tiling.ts
+++ b/src/tiling.ts
@@ -29,7 +29,8 @@ enum Direction {
 export class Tiler {
     private keybindings: Object;
 
-    private window: Entity | null = null;
+    window: Entity | null = null;
+
     private swap_window: Entity | null = null;
 
     constructor(ext: Ext) {
@@ -38,8 +39,7 @@ export class Tiler {
                 if (ext.auto_tiler && this.window) {
                     const window = ext.windows.get(this.window);
                     if (window) {
-                        ext.auto_tiler.toggle_orientation(ext);
-                        ext.set_overlay(window.rect());
+                        ext.auto_tiler.toggle_orientation(ext, window);
                     }
                 }
             },

--- a/src/tiling.ts
+++ b/src/tiling.ts
@@ -3,7 +3,6 @@ const Me = imports.misc.extensionUtils.getCurrentExtension();
 
 import * as Lib from 'lib';
 import * as Tags from 'tags';
-import * as Log from 'log';
 import * as GrabOp from 'grab_op';
 import * as Rect from 'rectangle';
 import * as window from 'window';

--- a/src/tiling.ts
+++ b/src/tiling.ts
@@ -184,8 +184,6 @@ export class Tiler {
                 let fix_diff = () => {
                     let diff = before.diff(crect);
 
-                    Log.debug(`R DIFF BEFORE: ${diff.fmt()}`);
-
                     diff.width -= diff.width % 64;
                     diff.height -= diff.height % 64;
 
@@ -201,8 +199,6 @@ export class Tiler {
                         diff.height = (diff.height + 64) * -1;
                     }
 
-                    Log.debug(`R DIFF CORRECTED: ${diff.fmt()}`);
-
                     let tmp = before.clone();
                     tmp.apply(diff);
                     crect = tmp;
@@ -217,11 +213,8 @@ export class Tiler {
                     grab_op.rect = crect.clone();
                 };
 
-                Log.debug(`R BEFORE: ${crect.fmt()}`);
                 resize(mov1, callback);
-                Log.debug(`R MID: ${crect.fmt()}`);
                 resize(mov2, callback);
-                Log.debug(`R AFTER: ${crect.fmt()}`);
 
                 ext.auto_tiler.forest.arrange(ext, fork.workspace);
 
@@ -454,7 +447,6 @@ export class Tiler {
 
             if (!ext.auto_tiler || ext.contains_tag(win.entity, Tags.Floating)) {
                 // Make sure overlay is valid
-                global.log(`make sure overlay is valid`);
                 this.rect_by_active_area(ext, (_monitor, rect) => {
                     this.change(ext.overlay, rect, 0, 0, 0, 0);
                 });

--- a/src/tiling.ts
+++ b/src/tiling.ts
@@ -218,7 +218,7 @@ export class Tiler {
 
                 ext.auto_tiler.forest.arrange(ext, fork.workspace);
 
-                Tweener.on_tween_completion(window.meta, () => {
+                Tweener.on_window_tweened(window.meta, () => {
                     ext.register_fn(() => ext.set_overlay(window.rect()));
                 });
             }
@@ -309,7 +309,7 @@ export class Tiler {
         }
 
         if (watching) {
-            Tweener.on_tween_completion(watching.meta, () => {
+            Tweener.on_window_tweened(watching.meta, () => {
                 ext.register_fn(() => {
                     if (watching) {
                         ext.set_overlay(watching.rect());

--- a/src/tweener.ts
+++ b/src/tweener.ts
@@ -26,10 +26,20 @@ export function is_tweening(a: Clutter.Actor) {
         || a.get_transition('scale-x');
 }
 
-export function on_tween_completion(meta: Meta.Window, callback: () => void): SignalID {
-    return GLib.timeout_add(150, GLib.PRIORITY_DEFAULT, () => {
+export function on_window_tweened(meta: Meta.Window, callback: () => void): SignalID {
+    return GLib.timeout_add(GLib.PRIORITY_DEFAULT, 150, () => {
         const actor = meta.get_compositor_private();
         if (actor && is_tweening(actor)) return true;
+
+        callback();
+
+        return false;
+    });
+}
+
+export function on_actor_tweened(actor: Clutter.Actor, callback: () => void): SignalID {
+    return GLib.timeout_add(GLib.PRIORITY_DEFAULT, 150, () => {
+        if (is_tweening(actor)) return true;
 
         callback();
 

--- a/src/window.ts
+++ b/src/window.ts
@@ -204,7 +204,7 @@ export class ShellWindow {
                 }
 
                 ext.tween_signals.set(entity_string, [
-                    Tweener.on_tween_completion(this.meta, onComplete),
+                    Tweener.on_window_tweened(this.meta, onComplete),
                     onComplete
                 ]);
             } else {

--- a/src/window.ts
+++ b/src/window.ts
@@ -172,6 +172,9 @@ export class ShellWindow {
                 ext.register({ tag: 2, window: this, kind: { tag: 1, rect: clone } });
                 if (on_complete) ext.register_fn(on_complete);
                 ext.tween_signals.delete(entity_string);
+                if (ext.active_hint?.is_tracking(this.entity)) {
+                    ext.active_hint.show();
+                }
             };
 
             if (ext.animate_windows && !ext.init) {
@@ -195,6 +198,10 @@ export class ShellWindow {
                     duration: 149,
                     mode: null,
                 });
+
+                if (ext.active_hint?.is_tracking(this.entity)) {
+                    ext.active_hint.hide();
+                }
 
                 ext.tween_signals.set(entity_string, [
                     Tweener.on_tween_completion(this.meta, onComplete),


### PR DESCRIPTION
Pulled fixes that have been implemented along the way towards supporting stacked tiles.

- Reduces CPU cycles consumed during animations
- Toggling orientation twice will swap branches in a node
- Improves tracking and movements of the active hints
- Fixes the overlay not updating on an orientation toggle
- Fixes the notifications containing error messages from Pop Shell
- The tree is now rebalanced on detach of a window
- Fixes #449  
- Fixes #345 
- Closes #153 
- Fixes #437 

May also fix some of our outstanding active hint placement issues.

Commit c9765823bdd0e348089d39d1c50b394e29bb802f might fix the blurry windows

The stacking branch will be rebased once this is merged