### PR TITLE
added emacs ctrl-n and ctrl-p bindings for search selection in launcher

### DIFF
--- a/src/search.ts
+++ b/src/search.ts
@@ -88,7 +88,7 @@ export class Search {
             }
 
             let s = event.get_state();
-            if (c == 65362 || (s == Clutter.ModifierType.CONTROL_MASK && c == 107)) {
+            if (c == 65362 || (s == Clutter.ModifierType.CONTROL_MASK && c == 107) || (s == Clutter.ModifierType.CONTROL_MASK && c == 112)) {
                 // Up arrow was pressed
                 if (0 < this.active_id) {
                     this.unselect();
@@ -100,7 +100,7 @@ export class Search {
                 	this.active_id = this.widgets.length - 1;
                 	this.select();
                 }
-            } else if (c == 65364 || (s == Clutter.ModifierType.CONTROL_MASK && c == 106)) {
+            } else if (c == 65364 || (s == Clutter.ModifierType.CONTROL_MASK && c == 106) || (s == Clutter.ModifierType.CONTROL_MASK && c == 110)) {
                 // Down arrow was pressed
                 if (this.active_id + 1 < this.widgets.length) {
                     this.unselect();


### PR DESCRIPTION
For users familiar with the Rofi launcher and i3WM, selecting applications using the Emacs bindings of CTRL-N and CTRL-P is a bit of an ingrained habit. Adding the additional keybindings will also be useful any Emacs users using the Pop Shell that aren't i3 users.