### PR TITLE
fix(hint): hide hint on max refocus

### DIFF
--- a/src/active_hint.ts
+++ b/src/active_hint.ts
@@ -66,6 +66,7 @@ export class ActiveHint {
     }
 
     restack(actor: Clutter.Actor) {
+        this.hide();
         if (this.tracked) {
             if (this.tracked.workspace === global.workspace_manager.get_active_workspace_index()) {
                 // Avoid restacking if the window is maximized / fullscreen
@@ -76,15 +77,11 @@ export class ActiveHint {
                 // Do not show the boxes when the window being tracked is minimized
                 if (!this.tracked.meta.minimized) {
                     this.show();
-                } else {
-                    this.hide();
                 }
 
                 for (const box of this.border) {
                     global.window_group.set_child_above_sibling(box, actor);
                 }
-            } else {
-                this.hide();
             }
         }
     }

--- a/src/auto_tiler.ts
+++ b/src/auto_tiler.ts
@@ -50,11 +50,21 @@ export class AutoTiler {
     update_toplevel(ext: Ext, fork: Fork, monitor: number, smart_gaps: boolean) {
         let rect = ext.monitor_work_area(monitor);
 
-        if (!(smart_gaps && fork.right === null)) {
-            rect.x += ext.gap_outer;
-            rect.y += ext.gap_outer;
-            rect.width -= ext.gap_outer * 2;
-            rect.height -= ext.gap_outer * 2;
+        if (!fork.right) {
+            if (smart_gaps) {
+                if ((ext.active_hint && fork.left.kind === 1 && ext.active_hint.is_tracking(fork.left.entity))) {
+                    ext.active_hint.hide();
+                }
+            } else {
+                rect.x += ext.gap_outer;
+                rect.y += ext.gap_outer;
+                rect.width -= ext.gap_outer * 2;
+                rect.height -= ext.gap_outer * 2;
+
+                if (ext.active_hint && fork.left.kind === 1 && ext.active_hint.is_tracking(fork.left.entity)) {
+                    ext.active_hint.show();
+                }
+            }
         }
 
         fork.smart_gaps = smart_gaps;


### PR DESCRIPTION
This only fixes the maximized window being re-focused, no hints. 

The global.display knows which window is really being focused - that's why the active hint on minimized was fixed on #487 but seemed to introduce #493.

But the tiler is moving windows and the display emits focus events on float during that time.