### PR TITLE
Re-enable Wayland support

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1130,7 +1130,7 @@ export class Ext extends Ecs.System<ExtEvent> {
 
         // Modes
 
-        if (this.settings.tile_by_default() && !this.auto_tiler && !utils.is_wayland()) {
+        if (this.settings.tile_by_default() && !this.auto_tiler) {
             Log.info(`tile by default enabled`);
 
             this.auto_tiler = new auto_tiler.AutoTiler(
@@ -1213,8 +1213,6 @@ export class Ext extends Ecs.System<ExtEvent> {
     }
 
     toggle_tiling() {
-        if (utils.is_wayland()) return;
-
         if (this.auto_tiler) {
             Log.info(`tile by default disabled!`);
             this.unregister_storage(this.auto_tiler.attached);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -435,7 +435,7 @@ export class Ext extends Ecs.System<ExtEvent> {
         this.column_size = this.settings.column_size() * this.dpi;
         this.row_size = this.settings.row_size() * this.dpi;
 
-        if (this.settings.active_hint() && !this.active_hint) {
+        if (this.settings.active_hint() && !this.active_hint && !utils.is_wayland()) {
             this.active_hint = new active_hint.ActiveHint(this.dpi);
         }
     }
@@ -450,6 +450,8 @@ export class Ext extends Ecs.System<ExtEvent> {
     }
 
     on_active_hint() {
+        if (utils.is_wayland()) return;
+
         if (this.settings.active_hint()) {
             this.active_hint = new active_hint.ActiveHint(this.dpi);
 

--- a/src/panel_settings.ts
+++ b/src/panel_settings.ts
@@ -51,15 +51,17 @@ export class Indicator {
         this.button.menu.addMenuItem(settings_button(this.button.menu));
         this.button.menu.addMenuItem(menu_separator(''));
 
-        this.button.menu.addMenuItem(
-            toggle(
-                _("Show Active Hint"),
-                ext.settings.active_hint(),
-                (toggle) => {
-                    ext.settings.set_active_hint(toggle.state);
-                }
-            )
-        );
+        if (!Utils.is_wayland()) {
+            this.button.menu.addMenuItem(
+                toggle(
+                    _("Show Active Hint"),
+                    ext.settings.active_hint(),
+                    (toggle) => {
+                        ext.settings.set_active_hint(toggle.state);
+                    }
+                )
+            );
+        }
 
         this.button.menu.addMenuItem(
             number_entry(

--- a/src/panel_settings.ts
+++ b/src/panel_settings.ts
@@ -2,6 +2,7 @@ const Me = imports.misc.extensionUtils.getCurrentExtension();
 
 // import * as auto_tiler from 'auto_tiler';
 import * as Log from 'log';
+import * as Utils from 'utils';
 
 //import type { Entity } from './ecs';
 import type { Ext } from './extension';
@@ -39,7 +40,11 @@ export class Indicator {
         this.button.add_actor(this.button.icon);
 
         this.button.menu.addMenuItem(tiled(ext));
-        this.button.menu.addMenuItem(show_title(ext));
+
+        if (!Utils.is_wayland()) {
+            this.button.menu.addMenuItem(show_title(ext));
+        }
+
         this.button.menu.addMenuItem(menu_separator(''));
 
         this.button.menu.addMenuItem(shortcuts(this.button.menu));


### PR DESCRIPTION
It seems to be working now, although I had to disable the active hint feature since it causes issues. The window title support also does not work in Wayland since we don't have an xprop equivalent.

Closes #166