### PR TITLE
fix: active-hint updates

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -438,7 +438,6 @@ export class Ext extends Ecs.System<ExtEvent> {
     }
 
     on_active_workspace_changed() {
-        this.show_border_on_focused();
         this.exit_modes();
         this.last_focused = null;
     }
@@ -1095,7 +1094,7 @@ export class Ext extends Ecs.System<ExtEvent> {
         });
 
         this.connect(global.window_manager, 'switch-workspace', () => {
-            this.show_border_on_focused();
+            this.hide_all_borders();
         });
 
         this.connect(workspace_manager, 'active-workspace-changed', () => {

--- a/src/window.ts
+++ b/src/window.ts
@@ -27,10 +27,16 @@ const WM_TITLE_BLACKLIST: Array<string> = [
     'Tor Browser'
 ];
 
-export enum RESTACK_STATE {
+enum RESTACK_STATE {
     RAISED,
     WORKSPACE_CHANGED,
     NORMAL
+}
+
+enum RESTACK_SPEED {
+    RAISED = 430,
+    WORKSPACE_CHANGED = 300,
+    NORMAL = 200
 }
 
 interface X11Info {
@@ -56,7 +62,7 @@ export class ShellWindow {
         xid_: new OnceCell()
     };
 
-    private _border: St.Bin = new St.Bin({ style_class: 'window-clone-border' });
+    private _border: St.Bin = new St.Bin({ style_class: 'pop-shell-active-hint' });
 
     private _border_size = 0;
 
@@ -316,20 +322,23 @@ export class ShellWindow {
     }
 
     /**
-     * This current does not work properly on Workspace change when single window
-     * because GNOME Shell puts the Window Actor at the top of the border.
-     *
-     * The update_border_layout() adds a padding outside instead to compensate.
+     * Sort the window group/always top group with each window border
+     * @param updateState NORMAL, RAISED, WORKSPACE_CHANGED
      */
     restack(updateState: RESTACK_STATE = RESTACK_STATE.NORMAL) {
 
-        const WORKSPACE_SPEED = 250;
-        const NORMAL_SPEED = 100;
+        let restackSpeed = RESTACK_SPEED.NORMAL;
 
-        let restackSpeed = NORMAL_SPEED;
-
-        if (updateState === RESTACK_STATE.RAISED || updateState === RESTACK_STATE.WORKSPACE_CHANGED) {
-            restackSpeed = WORKSPACE_SPEED;
+        switch (updateState) {
+            case RESTACK_STATE.NORMAL:
+                restackSpeed = RESTACK_SPEED.NORMAL
+                break;
+            case RESTACK_STATE.RAISED:
+                restackSpeed = RESTACK_SPEED.RAISED
+                break;
+            case RESTACK_STATE.WORKSPACE_CHANGED:
+                restackSpeed = RESTACK_SPEED.WORKSPACE_CHANGED
+                break;
         }
 
         GLib.timeout_add(GLib.PRIORITY_LOW, restackSpeed, () => {

--- a/src/window.ts
+++ b/src/window.ts
@@ -93,7 +93,7 @@ export class ShellWindow {
 
         if (this.meta.get_compositor_private()?.get_stage())
             this._on_style_changed();
-        
+
         this._update_border_layout();
     }
 
@@ -296,7 +296,10 @@ export class ShellWindow {
     show_border() {
         if (this.ext.settings.active_hint()) {
             let border = this._border;
-            if (!this.is_maximized() && !this.meta.minimized && this.same_workspace()) {
+            if (!this.is_maximized() &&
+                !this.meta.minimized &&
+                !this.meta.is_fullscreen() &&
+                this.same_workspace()) {
                 border.show();
             }
             this.restack();
@@ -333,7 +336,7 @@ export class ShellWindow {
             let border = this._border;
             let actor = this.meta.get_compositor_private();
             let win_group = global.window_group;
-    
+
             if (actor && border && win_group) {
                 // move the border above the window group first
                 win_group.set_child_above_sibling(border, null);
@@ -384,7 +387,7 @@ export class ShellWindow {
 
         border.set_position(frameX - borderSize, frameY - borderSize);
         border.set_size(frameWidth + 2 * borderSize, frameHeight + 2 * borderSize);
-        
+
         this.restack();
     }
 

--- a/src/window.ts
+++ b/src/window.ts
@@ -56,7 +56,7 @@ export class ShellWindow {
         xid_: new OnceCell()
     };
 
-    private _border: St.Bin = new St.Bin({ style_class: 'pop-shell-active-hint' });
+    private _border: St.Bin = new St.Bin({ style_class: 'window-clone-border' });
 
     private _border_size = 0;
 

--- a/src/window.ts
+++ b/src/window.ts
@@ -15,7 +15,7 @@ import type { Ext } from './extension';
 import type { Rectangle } from './rectangle';
 
 // const GLib: GLib = imports.gi.GLib;
-const { Gdk, Meta, Shell, St } = imports.gi;
+const { Gdk, Meta, Shell, St, GLib } = imports.gi;
 
 const { OnceCell } = once_cell;
 
@@ -26,6 +26,12 @@ const WM_TITLE_BLACKLIST: Array<string> = [
     'Nightly', // Firefox Nightly
     'Tor Browser'
 ];
+
+export enum RESTACK_STATE {
+    RAISED,
+    WORKSPACE_CHANGED,
+    NORMAL
+}
 
 interface X11Info {
     normal_hints: once_cell.OnceCell<lib.SizeHint | null>;
@@ -85,11 +91,10 @@ export class ShellWindow {
 
         global.window_group.add_child(this._border);
 
-        this.restack();
-
-        if (this.meta.get_compositor_private()?.get_stage()) {
+        if (this.meta.get_compositor_private()?.get_stage())
             this._on_style_changed();
-        }
+        
+        this._update_border_layout();
     }
 
     get border() {
@@ -313,17 +318,56 @@ export class ShellWindow {
      *
      * The update_border_layout() adds a padding outside instead to compensate.
      */
-    restack() {
-        let border = this._border;
-        let actor = this.meta.get_compositor_private();
-        let win_group = global.window_group;
+    restack(updateState: RESTACK_STATE = RESTACK_STATE.NORMAL) {
 
-        if (actor && actor.get_parent() === border.get_parent()) {
-            win_group.set_child_above_sibling(border, actor);
-        } else {
-            win_group.set_child_above_sibling(border, null);
+        const WORKSPACE_SPEED = 250;
+        const NORMAL_SPEED = 100;
+
+        let restackSpeed = NORMAL_SPEED;
+
+        if (updateState === RESTACK_STATE.RAISED || updateState === RESTACK_STATE.WORKSPACE_CHANGED) {
+            restackSpeed = WORKSPACE_SPEED;
         }
-        this._update_border_layout();
+
+        GLib.timeout_add(GLib.PRIORITY_LOW, restackSpeed, () => {
+            let border = this._border;
+            let actor = this.meta.get_compositor_private();
+            let win_group = global.window_group;
+    
+            if (actor && border && win_group) {
+                // move the border above the window group first
+                win_group.set_child_above_sibling(border, null);
+
+                if (this.always_top_windows.length > 0) {
+                    // honor the always-top windows
+                    for (const above_actor of this.always_top_windows) {
+                        if (actor != above_actor) {
+                            if (border.get_parent() === above_actor.get_parent()) {
+                                win_group.set_child_below_sibling(border, above_actor);
+                            }
+                        }
+                    }
+
+                    // finally, move the border above the current window actor
+                    if (border.get_parent() === actor.get_parent()) {
+                        win_group.set_child_above_sibling(border, actor);
+                    }
+                }
+            }
+
+            return false; // make sure it runs once
+        });
+    }
+
+    get always_top_windows(): Clutter.Actor[] {
+        let above_windows: Clutter.Actor[] = new Array();
+
+        for (const actor of global.get_window_actors()) {
+            if (actor && actor.get_meta_window() && actor.get_meta_window().is_above())
+                above_windows.push(actor);
+        }
+
+        return above_windows;
     }
 
     hide_border() {
@@ -340,16 +384,16 @@ export class ShellWindow {
 
         border.set_position(frameX - borderSize, frameY - borderSize);
         border.set_size(frameWidth + 2 * borderSize, frameHeight + 2 * borderSize);
+        
+        this.restack();
     }
 
     private _bind_window_events() {
         let windowSignals = [
-            this.meta.connect('size-changed', () => {
-                this._window_changed();
-            }),
-            this.meta.connect('position-changed', () => {
-                this._window_changed();
-            }),
+            this.meta.connect('size-changed', () => { this._window_changed() }),
+            this.meta.connect('position-changed', () => { this._window_changed() }),
+            this.meta.connect('workspace-changed', () => { this._workspace_changed() }),
+            this.meta.connect('raised', () => { this._window_raised() }),
         ];
 
         let extWinSignals = this.ext.window_signals.get_or(this.entity, () => new Array());
@@ -358,6 +402,16 @@ export class ShellWindow {
 
     private _window_changed() {
         this.ext.show_border_on_focused();
+        this._update_border_layout();
+    }
+
+    private _window_raised() {
+        this.restack(RESTACK_STATE.RAISED);
+        this.show_border();
+    }
+
+    private _workspace_changed() {
+        this.restack(RESTACK_STATE.WORKSPACE_CHANGED);
     }
 
     private _on_style_changed() {


### PR DESCRIPTION
Issue fixes:
- Closes #452
- Closes #427
- Fixes #214

Updates:
- Use the window-clone-border for now to update the color when the theme changes. Putting the active-hint css in the local `dark` or `light` css files does not seem to toggle the color when changing themes.