### PR TITLE
feat: logging levels for development (Default OFF)

### DIFF
--- a/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
@@ -221,5 +221,17 @@
             <default>'rgba(251, 184, 108, 1)'</default>
             <summary>The current active-hint-color in RGBA</summary>
         </key>
+        <key type="u" name="log-level">
+            <default>0</default>
+            <summary>
+                Derive some log4j level/order
+                0 - OFF
+                1 - ERROR
+                2 - WARN
+                3 - INFO
+                4 - DEBUG
+            </summary>
+        </key>
+
     </schema>
 </schemalist>

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ const Me = imports.misc.extensionUtils.getCurrentExtension();
 const { Gio, GLib } = imports.gi;
 
 import * as error from 'error';
-import * as Log from 'log';
+import * as log from 'log';
 import * as result from 'result';
 
 import type { Result } from 'result';
@@ -62,7 +62,7 @@ export class Config {
         const conf = Config.from_config();
 
         if (conf.kind === 2) {
-            Log.error(`failed to open pop-shell config: ${conf.value.format()}`);
+            log.error(`failed to open pop-shell config: ${conf.value.format()}`);
             return;
         }
 
@@ -78,7 +78,7 @@ export class Config {
         try {
             return JSON.parse(json);
         } catch (error) {
-            Log.error(`failed to parse config: ${error}`);
+            log.error(`failed to parse config: ${error}`);
             return new Config();
         }
     }
@@ -140,7 +140,7 @@ export class Config {
     sync_to_disk() {
         const result = Config.write(this.to_json());
         if (result.kind === 2) {
-            Log.error(`failed to sync disk to config: ${result.value.format()}`);
+            log.error(`failed to sync disk to config: ${result.value.format()}`);
         }
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import * as Focus from 'focus';
 import * as GrabOp from 'grab_op';
 import * as Keybindings from 'keybindings';
 import * as Lib from 'lib';
-import * as Log from 'log';
+import * as log from 'log';
 import * as PanelSettings from 'panel_settings';
 import * as Rect from 'rectangle';
 import * as Settings from 'settings';
@@ -651,7 +651,7 @@ export class Ext extends Ecs.System<ExtEvent> {
                 msg += `  fork: (${this.auto_tiler.attached.get(win.entity)}),\n`;
             }
 
-            Log.debug(msg + '}');
+            log.debug(msg + '}');
         }
 
         // Log.debug(`Window(${win.entity}): parent: ${this.auto_tiler?.attached.get(win.entity)}`)
@@ -809,17 +809,17 @@ export class Ext extends Ecs.System<ExtEvent> {
                                 forest.tile(this, fork, fork.area);
                             }
                         } else {
-                            Log.error(`no fork component found`);
+                            log.error(`no fork component found`);
                         }
                     } else {
-                        Log.error(`no fork entity found`);
+                        log.error(`no fork entity found`);
                     }
                 }
             } else if (this.settings.snap_to_grid()) {
                 this.tiler.snap(this, win);
             }
         } else {
-            Log.error(`mismatch on grab op entity`);
+            log.error(`mismatch on grab op entity`);
         }
 
         this.grab_op = null;
@@ -1717,12 +1717,12 @@ let indicator: Indicator | null = null;
 
 // @ts-ignore
 function init() {
-    Log.info("init");
+    log.info("init");
 }
 
 // @ts-ignore
 function enable() {
-    Log.info("enable");
+    log.info("enable");
 
     if (!ext) {
         ext = new Ext();
@@ -1751,7 +1751,7 @@ function enable() {
 
 // @ts-ignore
 function disable() {
-    Log.info("disable");
+    log.info("disable");
 
     if (ext) {
         ext.signals_remove();
@@ -1834,7 +1834,7 @@ function load_theme(style: Style): string | any {
 
         return pop_stylesheet_path;
     } catch (e) {
-        Log.error("failed to load stylesheet: " + e);
+        log.error("failed to load stylesheet: " + e);
         return null;
     }
 }

--- a/src/forest.ts
+++ b/src/forest.ts
@@ -4,7 +4,7 @@ const Me = imports.misc.extensionUtils.getCurrentExtension();
 import * as arena from 'arena';
 import * as Ecs from 'ecs';
 import * as Lib from 'lib';
-import * as Log from 'log';
+import * as log from 'log';
 import * as movement from 'movement';
 import * as Rect from 'rectangle';
 import * as Node from 'node';
@@ -608,7 +608,7 @@ export class Forest extends Ecs.World {
 
             this.delete_entity(child_entity);
         } else {
-            Log.error(`Fork(${child_entity}) does not exist`);
+            log.error(`Fork(${child_entity}) does not exist`);
         }
     }
 
@@ -833,14 +833,14 @@ export class Forest extends Ecs.World {
 
 function move_window(ext: Ext, window: ShellWindow, rect: Rectangular, on_complete: () => void) {
     if (!(window.meta instanceof Meta.Window)) {
-        Log.error(`attempting to a window entity in a tree which lacks a Meta.Window`);
+        log.error(`attempting to a window entity in a tree which lacks a Meta.Window`);
         return;
     }
 
     const actor = window.meta.get_compositor_private();
 
     if (!actor) {
-        Log.warn(`Window(${window.entity}) does not have an actor, and therefore cannot be moved`);
+        log.warn(`Window(${window.entity}) does not have an actor, and therefore cannot be moved`);
         return;
     }
 

--- a/src/forest.ts
+++ b/src/forest.ts
@@ -159,10 +159,10 @@ export class Forest extends Ecs.World {
 
                 return [fork.entity, fork];
             } else {
-                Log.warn('attempted to attach window to stack that does not exist');
+                log.warn('attempted to attach window to stack that does not exist');
             }
         } else {
-            Log.warn('attempted to attach to stack that does not exist');
+            log.warn('attempted to attach to stack that does not exist');
         }
 
         return null;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -2,7 +2,7 @@
 // @ts-ignore
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 
-import * as Log from 'log';
+import * as log from 'log';
 import * as rectangle from 'rectangle';
 
 import type { Rectangle } from 'rectangle';
@@ -41,7 +41,7 @@ export function bench<T>(name: string, callback: () => T): T {
     const value = callback();
     const end = new Date().getMilliseconds();
 
-    Log.info(`bench ${name}: ${end - start} ms elapsed`);
+    log.info(`bench ${name}: ${end - start} ms elapsed`);
 
     return value;
 }
@@ -59,7 +59,7 @@ export function cursor_rect(): Rectangle {
 }
 
 export function dbg<T>(value: T): T {
-    Log.debug(String(value));
+    log.debug(String(value));
     return value;
 }
 

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,21 +1,47 @@
-var log_level = 4;
+const ExtensionUtils = imports.misc.extensionUtils;
+
+// simplified log4j levels
+export enum LOG_LEVELS {
+    OFF,
+    ERROR,
+    WARN,
+    INFO,
+    DEBUG
+}
+
+/**
+ * parse level at runtime so we don't have to restart popshell
+ */
+export function log_level() {
+    // log.js is at the level of prefs.js where the popshell Ext instance 
+    // is not yet available or visible, so we have to use the built in 
+    // ExtensionUtils to get the current settings
+    let settings = ExtensionUtils.getSettings();
+    let log_level = settings.get_uint('log-level');
+
+    return log_level;
+}
 
 export function log(text: string) {
     global.log("pop-shell: " + text);
 }
 
-export function info(text: string) {
-    if (log_level > 0) log(" [INFO] " + text);
-}
-
 export function error(text: string) {
-    if (log_level > 1) log("[ERROR] " + text);
+    if (log_level() > LOG_LEVELS.OFF)
+        log("[ERROR] " + text);
 }
 
 export function warn(text: string) {
-    if (log_level > 2) log(" [WARN] " + text);
+    if (log_level() > LOG_LEVELS.ERROR)
+        log(" [WARN] " + text);
+}
+
+export function info(text: string) {
+    if (log_level() > LOG_LEVELS.WARN)
+        log(" [INFO] " + text);
 }
 
 export function debug(text: string) {
-    if (log_level > 3) log("[DEBUG] " + text);
+    if (log_level() > LOG_LEVELS.INFO)
+        log("[DEBUG] " + text);
 }

--- a/src/panel_settings.ts
+++ b/src/panel_settings.ts
@@ -74,10 +74,6 @@ export class Indicator {
                 }
             )
         )
-
-        // determine logging
-        this.button.menu.addMenuItem(menu_separator(''));
-        this.button.menu.addMenuItem(log_level_item(ext));
     }
 
     destroy() {
@@ -87,23 +83,6 @@ export class Indicator {
 
 function menu_separator(text: any): any {
     return new PopupSeparatorMenuItem(text);
-}
-
-function log_level_item(ext: Ext) {
-    // initial value
-    let log_level_txt = log.LOG_LEVELS[ext.settings.log_level()];
-    let item = new PopupMenuItem(`Log Level: ${log_level_txt}`);
-
-    ext.settings.ext.connect('changed', (_, key) => {
-        if (key === 'log-level') {
-            let log_val = log.LOG_LEVELS[ext.settings.log_level()];
-            item.label.set_text(`Log Level: ${log_val}`);
-        }
-    });
-    
-    item.label.get_clutter_text().set_x_expand(true);
-    item.label.set_y_align(Clutter.ActorAlign.CENTER);
-    return item;
 }
 
 function settings_button(menu: any): any {

--- a/src/panel_settings.ts
+++ b/src/panel_settings.ts
@@ -1,7 +1,7 @@
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 
 // import * as auto_tiler from 'auto_tiler';
-import * as Log from 'log';
+import * as log from 'log';
 import * as Utils from 'utils';
 
 //import type { Entity } from './ecs';
@@ -74,6 +74,10 @@ export class Indicator {
                 }
             )
         )
+
+        // determine logging
+        this.button.menu.addMenuItem(menu_separator(''));
+        this.button.menu.addMenuItem(log_level_item(ext));
     }
 
     destroy() {
@@ -85,6 +89,23 @@ function menu_separator(text: any): any {
     return new PopupSeparatorMenuItem(text);
 }
 
+function log_level_item(ext: Ext) {
+    // initial value
+    let log_level_txt = log.LOG_LEVELS[ext.settings.log_level()];
+    let item = new PopupMenuItem(`Log Level: ${log_level_txt}`);
+
+    ext.settings.ext.connect('changed', (_, key) => {
+        if (key === 'log-level') {
+            let log_val = log.LOG_LEVELS[ext.settings.log_level()];
+            item.label.set_text(`Log Level: ${log_val}`);
+        }
+    });
+    
+    item.label.get_clutter_text().set_x_expand(true);
+    item.label.set_y_align(Clutter.ActorAlign.CENTER);
+    return item;
+}
+
 function settings_button(menu: any): any {
     let item = new PopupMenuItem(_('View All'));
     item.connect('activate', () => {
@@ -92,7 +113,7 @@ function settings_button(menu: any): any {
         if (path) {
             imports.misc.util.spawn([path]);
         } else {
-            Log.error(`You must install \`pop-shell-shortcuts\``)
+            log.error(`You must install \`pop-shell-shortcuts\``)
         }
 
         menu.close();
@@ -113,7 +134,7 @@ function shortcuts(menu: any): any {
         if (path) {
             imports.misc.util.spawn([path]);
         } else {
-            Log.error(`You must install \`pop-shell-shortcuts\``)
+            log.error(`You must install \`pop-shell-shortcuts\``)
         }
 
         menu.close();

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -1,13 +1,15 @@
 export { }
 
+const ExtensionUtils = imports.misc.extensionUtils;
 // @ts-ignore
-const Me = imports.misc.extensionUtils.getCurrentExtension();
+const Me = ExtensionUtils.getCurrentExtension();
 
 const { Gtk } = imports.gi;
 
 const { Settings } = imports.gi.Gio;
 
 import * as settings from 'settings';
+import * as log from 'log';
 
 interface AppWidgets {
     inner_gap: any,
@@ -102,7 +104,9 @@ function settings_dialog_view(): [AppWidgets, Gtk.Container] {
     grid.attach(smart_label, 0, 2, 1, 1);
     grid.attach(smart_gaps, 1, 2, 1, 1);
 
-    let [inner_gap, outer_gap] = gaps_section(grid, 3);
+    logging_combo(grid, 3);
+
+    let [inner_gap, outer_gap] = gaps_section(grid, 4);
 
     let settings = { inner_gap, outer_gap, smart_gaps, snap_to_grid, window_titles };
 
@@ -142,6 +146,37 @@ function gaps_section(grid: any, top: number): [any, any] {
 
 function number_entry(): Gtk.Widget {
     return new Gtk.Entry({ input_purpose: Gtk.InputPurpose.NUMBER });
+}
+
+function logging_combo(grid: any, top_index: number) {
+    let log_label = new Gtk.Label({
+        label: `Log Level`,
+        halign: Gtk.Align.START
+    });
+
+    grid.attach(log_label, 0, top_index, 1, 1);
+
+    let log_combo = new Gtk.ComboBoxText();
+
+    for (const key in log.LOG_LEVELS) {
+        // since log level loop will contain key and level,
+        // then cherry-pick the number, key will be the text value
+        if (typeof log.LOG_LEVELS[key] === 'number') {
+            log_combo.append(`${log.LOG_LEVELS[key]}`, key);
+        }
+    }
+
+    let current_log_level = log.log_level();
+
+    log_combo.set_active_id(`${current_log_level}`);
+    log_combo.connect("changed", () => {
+        let activeId = log_combo.get_active_id();
+        
+        let settings = ExtensionUtils.getSettings();
+        settings.set_uint('log-level', activeId);
+    });
+
+    grid.attach(log_combo, 1, top_index, 1, 1);
 }
 
 // @ts-ignore

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -12,7 +12,10 @@ interface Settings extends GObject.Object {
     set_uint(key: string, value: number): void;
 
     get_string(key: string): string;
-    set_string(key: string, value: string): void;}
+    set_string(key: string, value: string): void;
+
+    bind(key: string, object: GObject.Object, property: string, flags: any): void
+}
 
 function settings_new_id(schema_id: string): Settings | null {
     try {
@@ -55,6 +58,7 @@ const SNAP_TO_GRID = 'snap-to-grid';
 const TILE_BY_DEFAULT = 'tile-by-default';
 const HINT_COLOR_RGBA = 'hint-color-rgba';
 const DEFAULT_RGBA_COLOR = 'rgba(251, 184, 108, 1)'; //pop-orange
+const LOG_LEVEL = 'log-level';
 
 export class ExtensionSettings {
     ext: Settings = settings_new_schema(extension.metadata['settings-schema']);
@@ -134,6 +138,10 @@ export class ExtensionSettings {
             : false;
     }
 
+    log_level(): number {
+        return this.ext.get_uint(LOG_LEVEL);
+    }
+
     // Setters
 
     set_active_hint(set: boolean) {
@@ -180,5 +188,9 @@ export class ExtensionSettings {
 
     set_tile_by_default(set: boolean) {
         this.ext.set_boolean(TILE_BY_DEFAULT, set);
+    }
+
+    set_log_level(set: number) {
+        this.ext.set_uint(LOG_LEVEL, set);
     }
 }


### PR DESCRIPTION
- Added logging levels to help control the noise in journal. And let any extension developers to toggle this on their own. I had to add the current value in the panel icon, to give a first glance.
- Some of the current log imports had been renamed to just `log`.