### PR TITLE
fix: handle null entity on reparent, check parent before re-stacking siblings

### DIFF
--- a/src/forest.ts
+++ b/src/forest.ts
@@ -360,7 +360,9 @@ export class Forest extends Ecs.World {
                     window,
                     () => {
                         fork.right = null;
-                        this.reassign_to_parent(fork, fork.left, (fork.left.inner as any).entity)
+                        let entity = (fork.left.inner as any).entity;
+                        if (entity)
+                            this.reassign_to_parent(fork, fork.left, entity)
                     },
                 );
             }

--- a/src/stack.ts
+++ b/src/stack.ts
@@ -350,10 +350,13 @@ export class Stack {
         }
 
         if (!window.meta.is_fullscreen() && !window.is_maximized() && !this.ext.maximized_on_active_display()) {
-            parent.set_child_above_sibling(this.widgets.tabs, actor);
-            parent.set_child_above_sibling(this.border, this.widgets.tabs);
+            if (parent === this.widgets.tabs.get_parent() && parent === this.border.get_parent()) {
+                parent.set_child_above_sibling(this.widgets.tabs, actor);
+                parent.set_child_above_sibling(this.border, this.widgets.tabs);
+            }
         } else {
-            parent.set_child_below_sibling(this.widgets.tabs, actor);
+            if (parent === this.widgets.tabs.get_parent())
+                parent.set_child_below_sibling(this.widgets.tabs, actor);
         }
     }
 


### PR DESCRIPTION
Some small cleanup when moving stacked windows on different workspaces.