### PR TITLE
fix: check primary monitor workspace, no reflow

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -251,7 +251,11 @@ export class Ext extends Ecs.System<ExtEvent> {
 
                     case WindowEvent.Size:
                         if (this.auto_tiler && !win.is_maximized() && !win.meta.is_fullscreen()) {
-                            this.auto_tiler.reflow(this, win.entity);
+                            if (!this.settings.workspaces_only_on_primary()) {
+                                this.on_workspace_changed(win);
+                            } else {
+                                this.auto_tiler.reflow(this, win.entity);
+                            }
                         }
                         break
 


### PR DESCRIPTION
Do not reflow when workspace primary is disabled. 

Hopefully: 
- Fixes #522
- Fixes #246 - looks like a dupe of 522 or vice versa

I do not have 3 monitors.
Need testing on primary, secondary, secondary or secondary, primary, secondary setups.