### PR TITLE
fix: do not show border when stack window maxed

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -626,6 +626,7 @@ export class Ext extends Ecs.System<ExtEvent> {
             if (!ignore_stack && focus.stack !== null) {
                 const stack = ext?.auto_tiler?.forest.stacks.get(focus.stack);
                 if (stack) {
+                    focus.hide_border();
                     stack.show_border();
                 } else {
                     focus.show_border();

--- a/src/stack.ts
+++ b/src/stack.ts
@@ -460,8 +460,11 @@ export class Stack {
 
     show_border() {
         if (this.ext.settings.active_hint()) {
-            this.border.show();
-            this.restack();
+            const window = this.ext.windows.get(this.active);
+            if (window && !window.is_maximized() && !window.meta.is_fullscreen()) {
+                this.border.show();
+                this.restack();
+            }
         }
     }
 


### PR DESCRIPTION
Seeing border when a stacked window is maximized