### PR TITLE
fix: tweener stutter

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1138,8 +1138,6 @@ export class Ext extends Ecs.System<ExtEvent> {
         let win = this.get_window(window);
         if (win) {
             const entity = win.entity;
-            if (actor)
-                actor.hide();
             if (win && win.border)
                 win.border.hide();
             
@@ -1422,7 +1420,6 @@ export class Ext extends Ecs.System<ExtEvent> {
 
         if (this.init) {
             for (const window of this.tab_list(Meta.TabList.NORMAL, null)) {
-                // window.meta.get_compositor_private()?.hide();
                 this.register({ tag: 3, window: window.meta });
             }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1138,6 +1138,11 @@ export class Ext extends Ecs.System<ExtEvent> {
         let win = this.get_window(window);
         if (win) {
             const entity = win.entity;
+            if (actor)
+                actor.hide();
+            if (win && win.border)
+                win.border.hide();
+            
             actor.connect('destroy', () => {
                 if (win && win.border)
                     win.border.destroy();
@@ -1417,6 +1422,7 @@ export class Ext extends Ecs.System<ExtEvent> {
 
         if (this.init) {
             for (const window of this.tab_list(Meta.TabList.NORMAL, null)) {
+                // window.meta.get_compositor_private()?.hide();
                 this.register({ tag: 3, window: window.meta });
             }
 

--- a/src/tweener.ts
+++ b/src/tweener.ts
@@ -11,6 +11,7 @@ export interface TweenParams {
 
 export function add(a: Clutter.Actor, p: TweenParams) {
     if (!p.mode) p.mode = Clutter.AnimationMode.LINEAR;
+    remove(a);
     a.ease(p);
 }
 

--- a/src/tweener.ts
+++ b/src/tweener.ts
@@ -11,7 +11,6 @@ export interface TweenParams {
 
 export function add(a: Clutter.Actor, p: TweenParams) {
     if (!p.mode) p.mode = Clutter.AnimationMode.LINEAR;
-
     a.ease(p);
 }
 
@@ -23,16 +22,20 @@ export function is_tweening(a: Clutter.Actor) {
     return a.get_transition('x')
         || a.get_transition('y')
         || a.get_transition('scale-x')
-        || a.get_transition('scale-x');
+        || a.get_transition('scale-y');
 }
 
 export function on_window_tweened(meta: Meta.Window, callback: () => void): SignalID {
     return GLib.timeout_add(GLib.PRIORITY_DEFAULT, 150, () => {
         const actor = meta.get_compositor_private();
-        if (actor && is_tweening(actor)) return true;
-
-        callback();
-
+        if (actor) { 
+            if (is_tweening(actor)) {
+                return true
+            } else {
+                remove(actor);
+                callback();
+            }
+        }
         return false;
     });
 }

--- a/src/window.ts
+++ b/src/window.ts
@@ -239,10 +239,10 @@ export class ShellWindow {
                 ext.register({ tag: 2, window: this, kind: { tag: 1, rect: clone } });
                 if (on_complete) ext.register_fn(on_complete);
                 ext.tween_signals.delete(entity_string);
-
                 if (this.meta.appears_focused) {
                     this.show_border();
                 }
+
             };
 
             if (ext.animate_windows && !ext.init) {
@@ -261,10 +261,12 @@ export class ShellWindow {
                     callback();
                 }
 
-                const x = clone.x - dx;
-                const y = clone.y - dy;
-
-                Tweener.add(actor, { x, y, duration: 149, mode: null });
+                Tweener.add(actor, {
+                    x: clone.x - dx,
+                    y: clone.y - dy,
+                    duration: 275,
+                    mode: null,
+                });
 
                 ext.tween_signals.set(entity_string, [
                     Tweener.on_window_tweened(this.meta, onComplete),

--- a/src/window.ts
+++ b/src/window.ts
@@ -240,11 +240,6 @@ export class ShellWindow {
                 if (on_complete) ext.register_fn(on_complete);
                 ext.tween_signals.delete(entity_string);
 
-                if (ext.animate_windows) {
-                    actor.opacity = 255;
-                    actor.show();
-                }
-
                 if (this.meta.appears_focused) {
                     this.show_border();
                 }

--- a/src/window.ts
+++ b/src/window.ts
@@ -73,6 +73,7 @@ export class ShellWindow {
     private border_size = 0;
 
     constructor(entity: Entity, window: Meta.Window, window_app: any, ext: Ext) {
+        this.border.hide();
         this.window_app = window_app;
 
         this.entity = entity;
@@ -101,8 +102,6 @@ export class ShellWindow {
             this.on_style_changed();
         });
 
-        this.hide_border()
-
         global.window_group.add_child(this.border);
 
         this.restack();
@@ -110,7 +109,6 @@ export class ShellWindow {
         if (this.meta.get_compositor_private()?.get_stage())
             this.on_style_changed();
 
-        this.update_border_layout();
     }
 
     activate(): void {
@@ -241,6 +239,12 @@ export class ShellWindow {
                 ext.register({ tag: 2, window: this, kind: { tag: 1, rect: clone } });
                 if (on_complete) ext.register_fn(on_complete);
                 ext.tween_signals.delete(entity_string);
+
+                if (ext.animate_windows) {
+                    actor.opacity = 255;
+                    actor.show();
+                }
+
                 if (this.meta.appears_focused) {
                     this.show_border();
                 }


### PR DESCRIPTION
closes #547 - remove the extra animation after done tweening.
Also, need to check scale-y correctly when swapping vertically.