### PR TITLE
fix: redirect all hint logic to the active window

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -632,31 +632,16 @@ export class Ext extends Ecs.System<ExtEvent> {
 
     show_border_on_focused() {
         this.hide_all_borders();
-        const ignore_stack = this.grab_op !== null;
 
         const focus = this.focus_window();
         if (focus) {
-            if (!ignore_stack && focus.stack !== null) {
-                const stack = ext?.auto_tiler?.forest.stacks.get(focus.stack);
-                if (stack) {
-                    focus.hide_border();
-                    stack.show_border();
-                } else {
-                    focus.show_border();
-                }
-            } else {
-                focus.show_border();
-            }
+            focus.show_border();
         }
     }
 
     hide_all_borders() {
         for (const win of this.windows.values()) {
             win.hide_border();
-        }
-
-        if (this.auto_tiler) for (const stack of this.auto_tiler.forest.stacks.values()) {
-            stack.hide_border();
         }
     }
 
@@ -739,6 +724,8 @@ export class Ext extends Ecs.System<ExtEvent> {
         if (null == win || !win.is_tilable(this)) {
             return;
         }
+
+        win.grab = false;
 
         this.size_signals_unblock(win);
 
@@ -980,6 +967,8 @@ export class Ext extends Ecs.System<ExtEvent> {
     on_grab_start(meta: Meta.Window) {
         let win = this.get_window(meta);
         if (win) {
+            win.grab = true;
+
             if (win.is_tilable(this)) {
                 let entity = win.entity;
                 let rect = win.rect();

--- a/src/window.ts
+++ b/src/window.ts
@@ -51,6 +51,7 @@ export class ShellWindow {
     ext: Ext;
     stack: number | null = null;
     known_workspace: number;
+    grab: boolean = false;
 
     was_attached_to?: [Entity, boolean];
 
@@ -329,7 +330,7 @@ export class ShellWindow {
     }
 
     show_border() {
-        if (this.stack === null && this.ext.settings.active_hint()) {
+        if (this.ext.settings.active_hint()) {
             let border = this.border;
             if (!this.meta.is_fullscreen() &&
                 !this.meta.minimized &&
@@ -429,8 +430,24 @@ export class ShellWindow {
             border.add_style_class_name('pop-shell-border-maximize');
         }
 
-        border.set_position(frameX - borderSize, frameY - borderSize);
-        border.set_size(frameWidth + (2 * borderSize), frameHeight + (2 * borderSize));
+        let stack_number = this.stack;
+
+        if (stack_number !== null) {
+            const stack = this.ext.auto_tiler?.forest.stacks.get(stack_number);
+            if (stack) {
+                let stack_tab_height = stack.tabs_height;
+
+                if (borderSize === 0 || this.grab) { // not in max screen state
+                    stack_tab_height = 0;
+                }
+
+                border.set_position(frameX - borderSize, frameY - stack_tab_height - borderSize);
+                border.set_size(frameWidth + 2 * borderSize, frameHeight + stack_tab_height + 2 * borderSize);
+            }
+        } else {
+            border.set_position(frameX - borderSize, frameY - borderSize);
+            border.set_size(frameWidth + (2 * borderSize), frameHeight + (2 * borderSize));
+        }
 
         this.restack();
     }


### PR DESCRIPTION
Make the active window stack or not as the primary actor even for the active hint. Also this will reduce the build up of St.Bin in the window group