### PR TITLE
improv(rebuild.sh): offer to install TypeScript with npm if missing or too old

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ debian/*
 !debian/rules
 .confirm_shortcut_change
 .vscode
+node_modules
+package-lock.json

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -12,6 +12,20 @@ else
     echo "Shortcut change already confirmed"
 fi
 
+# Ensure TypeScript is new enough, offer to install with npm if not
+export PATH="./node_modules/.bin:$PATH"
+REQ_TSC_VER="3.8"
+CUR_TSC_VER=$(tsc --version 2>/dev/null || echo 0)
+CUR_TSC_VER=${CUR_TSC_VER##* }
+if [ "$(sort -V <<< ${REQ_TSC_VER}$'\n'${CUR_TSC_VER} | head -n1)" != "$REQ_TSC_VER" ]; then
+    read -p "TypeScript is not installed or is too old. Install locally using npm? (y/n) " CONT
+    if [ "$CONT" = "y" ]; then
+        npm install typescript
+    else
+        echo "OK. Attempting to continue, but except that the build will fail."
+    fi
+fi
+
 set -xe
 
 # Build and install extension


### PR DESCRIPTION
This should make it easier for users of distributions with too old TypeScript
versions (e.g., Fedora 32) to try Pop Shell.