### PR TITLE
fix: rebuild.sh to work on less common shell environments

### DIFF
--- a/rebuild.sh
+++ b/rebuild.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Check if user confirmed overriding shortcuts
 if [ ! -f "./.confirm_shortcut_change" ]; then
     read -p "Pop shell will override your default shortcuts. Are you sure? (y/n) " CONT


### PR DESCRIPTION
- rebuild.sh only works if you are using a supported shell (bash/zsh/sh), but not fish
- Adding shebang statement prevents fish from trying to interpret the script