### PR TITLE
fix: Activate window after moving across a monitor

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -946,8 +946,11 @@ export class Ext extends Ecs.System<ExtEvent> {
                         this.size_signals_unblock(win);
                     }
                 } else {
+
                     this.workspace_window_move(win, monitor, monitor);
                 }
+
+                win.activate_after_move = true;
             }
 
             if (neighbor && neighbor.index() !== ws.index()) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -235,14 +235,19 @@ export class Ext extends Ecs.System<ExtEvent> {
                     }
 
                     actor.remove_all_transitions();
-                    const r = event.kind.rect;
+                    const { x, y, width, height } = event.kind.rect;
 
-                    event.window.meta.move_resize_frame(true, r.x, r.y, r.width, r.height);
+                    event.window.meta.move_resize_frame(true, x, y, width, height);
 
                     this.monitors.insert(event.window.entity, [
                         win.meta.get_monitor(),
                         win.workspace_id()
                     ]);
+
+                    if (win.activate_after_move) {
+                        win.activate_after_move = false;
+                        win.activate();
+                    }
 
                     return;
                 }
@@ -909,6 +914,8 @@ export class Ext extends Ecs.System<ExtEvent> {
                 this.workspace_window_move(win, prev_monitor, next_monitor);
             }
         }
+
+        win.activate_after_move = true;
     }
 
     /** Moves the focused window across workspaces and displays */

--- a/src/window.ts
+++ b/src/window.ts
@@ -52,6 +52,7 @@ export class ShellWindow {
     stack: number | null = null;
     known_workspace: number;
     grab: boolean = false;
+    activate_after_move: boolean = false;
 
     was_attached_to?: [Entity, boolean];
 
@@ -102,12 +103,12 @@ export class ShellWindow {
         });
 
         this.hide_border()
-        
+
         let settings = ext.settings;
         let selected_color = settings.hint_color_rgba();
-    
+
         this.border.set_style(`border-color: ${selected_color}`);
-        
+
         let change_id = settings.ext.connect('changed', (_, key) => {
             if (this.border) {
                 if (key === 'hint-color-rgba') {
@@ -117,7 +118,7 @@ export class ShellWindow {
             }
             return false;
         });
-        
+
         this.border.connect('destroy', () => { settings.ext.disconnect(change_id) });
 
         global.window_group.add_child(this.border);


### PR DESCRIPTION
This addresses the problem with focus-on-hover causing focus to be lost after a window is a moved to another monitor.

Closes #550