### PR TITLE
improv(rebuild.sh): offer to install TypeScript with npm if needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ debian/*
 !debian/rules
 .confirm_shortcut_change
 .vscode
+node_modules
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ There are additionally those who do want the traditional stacking window managem
 To install this GNOME Shell extension, you MUST have the following:
 
 - GNOME Shell 3.36
-- TypeScript 3.8
+- TypeScript 3.8 (or `npm`, which `rebuild.sh` will use to install TypeScript if necessary)
 - GNU Make
 
 Proper functionality of the shell requires modifying GNOME's default keyboard shortcuts. Those developing and testing the extension must run the `rebuild.sh` script to install it locally (do not use sudo): `sh rebuild.sh`.

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -13,6 +13,20 @@ else
     echo "Shortcut change already confirmed"
 fi
 
+# Ensure TypeScript is new enough, offer to install with npm if not
+export PATH="./node_modules/.bin:$PATH"
+REQ_TSC_VER="3.8"
+CUR_TSC_VER=$(tsc --version 2>/dev/null || echo 0)
+CUR_TSC_VER=${CUR_TSC_VER##* }
+if [ "$(/bin/echo -e "${REQ_TSC_VER}\n${CUR_TSC_VER}" | sort -V | head -n1)" != "$REQ_TSC_VER" ]; then
+    read -p "TypeScript is not installed or is too old. Install locally using npm? (y/n) " CONT
+    if [ "$CONT" = "y" ]; then
+        npm install typescript
+    else
+        echo "OK. Attempting to continue, but except that the build will fail."
+    fi
+fi
+
 set -xe
 
 # Build and install extension


### PR DESCRIPTION
This should make it easier for users of distributions with too old TypeScript versions (e.g., Fedora 32) to try Pop Shell.

This is a second attempt at this change. The first one (#569) was reverted because it did not work with the minimal `sh` found on Debian systems. In this updated version, the `<<<` redirection operator has been replaced with a standard `echo … | …` pipeline. This has been tested to work correctly in a minimal Debian container, using both `sh` and `bash`.