### PR TITLE
Integrate Pop-Shell Launcher with external scripts and programs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ debian/*
 !debian/rules
 .confirm_shortcut_change
 .vscode
+node_modules

--- a/EXTERNALLAUNCHER.md
+++ b/EXTERNALLAUNCHER.md
@@ -22,14 +22,17 @@ action="${2^^}"
 item_value="${3}"
 
 if [ ! -f "/tmp/bt.idx" ] || [ "$tag" != "$(cat /tmp/bt.idx)" ]; then
+    # New launcher opened, rebuild search index...
     echo "$tag">"/tmp/bt.idx"
     brotab index
 fi
 
 if [ "${action}" == "SEARCH" ]; then
     if [ -n "${item_value}" ]; then
-        brotab search "${item_value}*"
+        # Search tabs in browser, using query...
+        brotab search "${item_value}"
     else
+        # No search query yet provided, list current tabs in browser...
         active_ids="$(brotab active | cut -f1 | tr '\n' '|' | sed 's/\./\\./g')"
         regex="^(${active_ids::-1})\t"
         brotab list | grep -P "$regex"
@@ -38,7 +41,12 @@ fi
 
 if [ "${action}" == "APPLY" ]; then
     if [ -n "${item_value}" ]; then
+        # Activate tab in firefox, using brotab browser extension
         brotab activate --focused "${item_value}"
+        if [ -n "$4" ]; then
+            # Force X to focus window and workspace, using window title.
+            wmctrl -a "${4} - Mozilla Firefox"
+        fi
     fi
 fi
 ```

--- a/EXTERNALLAUNCHER.md
+++ b/EXTERNALLAUNCHER.md
@@ -1,10 +1,10 @@
 # Pop-Shell launcher: ExternalLauncher
-Type `.{script}` in the launcher, to call a script or program in ~/.pop-shell-launchers/ called `{script}` with either `{tag} list` or `{tag} apply`
+Type `.{script}` in the launcher, to call a script or program in ~/.pop-shell-launchers/ called `{script}` with either `{tag} search` or `{tag} apply`
 
 Scripts always receive 2 arguments:
-* tag: a unique session-id which only changes when the launcher window is displayed
-* action: a keyword of either **list** or **apply**
-    * **list**: must supply a newline separated list of tab separated values: `item-value \t display-name  \t [optional: icon-name]`  
+* tag: timestamp which changes each time the launcher window is displayed
+* action: a keyword of either **search** or **apply**
+    * **search**: must supply a newline separated list of tab separated values: `item-value \t display-name  \t [optional: icon-name]`  
     ExternalLauncher will cache list results using a compound key of `{tag}` and `{script}`
     * **apply**: is called with the additional arguments of the select item's `item-value` and  `display-name` values.
 
@@ -17,19 +17,30 @@ Here is an example of a script, called `bt`, that uses [brotab](https://github.c
 ```
 #!/usr/bin/env bash
 
-# echo "$0 $*">>/tmp/bt.log
-
 tag="${1}"
 action="${2^^}"
 item_value="${3}"
 
-if [ "${action}" == "LIST" ]; then
-    brotab list
+if [ ! -f "/tmp/bt.idx" ] || [ "$tag" != "$(cat /tmp/bt.idx)" ]; then
+    echo "$tag">"/tmp/bt.idx"
+    brotab index
+fi
+
+if [ "${action}" == "SEARCH" ]; then
+    if [ -n "${item_value}" ]; then
+        brotab search "${item_value}*"
+    else
+        active_ids="$(brotab active | cut -f1 | tr '\n' '|' | sed 's/\./\\./g')"
+        regex="^(${active_ids::-1})\t"
+        brotab list | grep -P "$regex"
+    fi
 fi
 
 if [ "${action}" == "APPLY" ]; then
-    brotab activate --focused "${item_value}"
+    if [ -n "${item_value}" ]; then
+        brotab activate --focused "${item_value}"
+    fi
 fi
 ```
 
-`.bt github pop-shell` now displays browser tabs containing "github pop-shell" in the title, and selecting it, focuses that tab in the browser.
+`./bt github pop-shell` now displays browser tabs containing "github pop-shell"; Selecting it, focuses that tab in the browser.

--- a/EXTERNALLAUNCHER.md
+++ b/EXTERNALLAUNCHER.md
@@ -17,22 +17,24 @@ Here is an example of a script, called `bt`, that uses [brotab](https://github.c
 ```
 #!/usr/bin/env bash
 
+#echo "$0 $*">>/tmp/bt.log
+
 tag="${1}"
 action="${2^^}"
 item_value="${3}"
 
 if [ ! -f "/tmp/bt.idx" ] || [ "$tag" != "$(cat /tmp/bt.idx)" ]; then
-    # New launcher opened, rebuild search index...
+    #echo "Rebuilding index">>/tmp/bt.log
     echo "$tag">"/tmp/bt.idx"
     brotab index
 fi
 
 if [ "${action}" == "SEARCH" ]; then
     if [ -n "${item_value}" ]; then
-        # Search tabs in browser, using query...
-        brotab search "${item_value}"
+        #echo "Searching for \"${item_value}*\"">>/tmp/bt.log
+        brotab search "${item_value}*"
     else
-        # No search query yet provided, list current tabs in browser...
+        #echo "Listing active tabs">>/tmp/bt.log
         active_ids="$(brotab active | cut -f1 | tr '\n' '|' | sed 's/\./\\./g')"
         regex="^(${active_ids::-1})\t"
         brotab list | grep -P "$regex"
@@ -41,11 +43,13 @@ fi
 
 if [ "${action}" == "APPLY" ]; then
     if [ -n "${item_value}" ]; then
-        # Activate tab in firefox, using brotab browser extension
+        #echo "Activating tab ${item_value}">>/tmp/bt.log
         brotab activate --focused "${item_value}"
         if [ -n "$4" ]; then
-            # Force X to focus window and workspace, using window title.
-            wmctrl -a "${4} - Mozilla Firefox"
+            sleep 0.1
+            focus="${4} - Mozilla Firefox"
+            wmctrl -a "$focus"
+            #echo "Switched focus to ${focus}">>/tmp/bt.log
         fi
     fi
 fi

--- a/EXTERNALLAUNCHER.md
+++ b/EXTERNALLAUNCHER.md
@@ -1,0 +1,35 @@
+# Pop-Shell launcher: ExternalLauncher
+Type `.{script}` in the launcher, to call a script or program in ~/.pop-shell-launchers/ called `{script}` with either `{tag} list` or `{tag} apply`
+
+Scripts always receive 2 arguments:
+* tag: a unique session-id which only changes when the launcher window is displayed
+* action: a keyword of either **list** or **apply**
+    * **list**: must supply a newline separated list of tab separated values: `item-value \t display-name  \t [optional: icon-name]`  
+    ExternalLauncher will cache list results using a compound key of `{tag}` and `{script}`
+    * **apply**: is called with the additional arguments of the select item's `item-value` and  `display-name` values.
+
+---
+
+## Example script
+
+Here is an example of a script, called `bt`, that uses [brotab](https://github.com/balta2ar/brotab) with firefox or google chrome, to control their tabs.
+
+```
+#!/usr/bin/env bash
+
+# echo "$0 $*">>/tmp/bt.log
+
+tag="${1}"
+action="${2^^}"
+item_value="${3}"
+
+if [ "${action}" == "LIST" ]; then
+    brotab list
+fi
+
+if [ "${action}" == "APPLY" ]; then
+    brotab activate --focused "${item_value}"
+fi
+```
+
+`.bt github pop-shell` now displays browser tabs containing "github pop-shell" in the title, and selecting it, focuses that tab in the browser.

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ By default, the launcher searches windows and applications. However, you can des
 - `t:`: Execute a command in `sh` in a terminal
 - `=`: Calculator mode, powered by [MathJS](https://mathjs.org/)
 - `d:` Recent documents
-- `.{script}` Calls a script or program in $HOME/.pop-shell-launchers/ called {script} with either `{tag} list` or `{tag} apply`  
+- `.{script}` Calls a script or program in $HOME/.pop-shell-launchers/ called {script} with either `{tag} search` or `{tag} apply`  
     See: [EXTERNALLAUNCHER.md](EXTERNALLAUNCHER.md) for an example script using [brotab](https://github.com/balta2ar/brotab) to control browser tabs.
 
 ### Inner and Outer Gaps

--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ By default, the launcher searches windows and applications. However, you can des
 - `:`: Execute a command in `sh`
 - `t:`: Execute a command in `sh` in a terminal
 - `=`: Calculator mode, powered by [MathJS](https://mathjs.org/)
+- `d:` Recent documents
+- `.{script}` Calls a script or program in $HOME/.pop-shell-launchers/ called {script} with either `{tag} list` or `{tag} apply`  
+    See: [EXTERNALLAUNCHER.md](EXTERNALLAUNCHER.md) for an example script using [brotab](https://github.com/balta2ar/brotab) to control browser tabs.
 
 ### Inner and Outer Gaps
 

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Check if user confirmed overriding shortcuts
 if [ ! -f "./.confirm_shortcut_change" ]; then
     read -p "Pop shell will override your default shortcuts. Are you sure? (y/n) " CONT

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -41,6 +41,7 @@ const MODES: launchers.LauncherExtension[] = [
     new launchers.CommandLauncher(),
     new launchers.CalcLauncher(),
     new launchers.RecentDocumentLauncher(),
+    new launchers.ExternalLauncher()
 ];
 
 export class Launcher extends search.Search {

--- a/src/launcherext.ts
+++ b/src/launcherext.ts
@@ -277,7 +277,7 @@ export class ExternalLauncher implements LauncherExtension {
                     const arr = line.split(/\t/);
 
                     const widget: St.Widget = widgets.application_button(
-                        `${arr[1]}\n- ${decodeURI(arr[2])}`,
+                        `${arr[1]}\n- ${arr[2]}`,
                         new St.Icon({
                             icon_name: 'applications-internet',
                             icon_size: (this.search?.icon_size() ?? DEFAULT_ICON_SIZE) / 2,

--- a/src/launcherext.ts
+++ b/src/launcherext.ts
@@ -204,7 +204,7 @@ export class ExternalLauncher implements LauncherExtension {
 
     ext?: Ext;
     search?: Search;
-    results?: Array<{id: string, widget: St.Widget}>;
+    results?: Array<{id: string, result: string[], widget: St.Widget}>;
 
     get_sesid(): number {
         if (this.search)
@@ -243,9 +243,9 @@ export class ExternalLauncher implements LauncherExtension {
         const cmd = this.get_cmd(query);
         if (!cmd) { return false; }
 
-        const result = this.results[index];
+        const item = this.results[index];
 
-        spawnCommandLine(`${cmd.action} ${cmd.tag} apply ${result.id}`);
+        spawnCommandLine(`${cmd.action} ${cmd.tag} apply ${item.id} "${item.result[1]}"`);
 
         return false;
     }
@@ -291,6 +291,7 @@ export class ExternalLauncher implements LauncherExtension {
 
                     this.results?.push({
                         id: arr[0],
+                        result: arr,
                         widget: widget
                     });
 

--- a/src/launcherext.ts
+++ b/src/launcherext.ts
@@ -251,7 +251,7 @@ export class ExternalLauncher implements LauncherExtension {
         const uri = this.results[index].uri;
         const display_name = this.results[index].display_name;
 
-        GLib.spawn_command_line_sync(`${cmd.action} ${cmd.tag} apply ${uri} "${display_name}"`);
+        spawnCommandLine(`${cmd.action} ${cmd.tag} apply ${uri} "${display_name}"`);
 
         return false;
     }

--- a/src/search.ts
+++ b/src/search.ts
@@ -9,6 +9,8 @@ const { ModalDialog } = imports.ui.modalDialog;
 export class Search {
     dialog: Shell.ModalDialog;
 
+    private session_id: number = Date.now();
+
     private active_id: number;
     private mode_prefixes: Array<string>;
     private entry: St.Entry;
@@ -116,6 +118,10 @@ export class Search {
         this.dialog.contentLayout.width = Math.max(Lib.current_monitor().width / 4, 640);
     }
 
+    get_session_id(): number {
+        return this.session_id;
+    }
+
     activate_option(id: number) {
         const cont = this.apply_cb(this.get_text(), id);
 
@@ -134,6 +140,7 @@ export class Search {
     }
 
     close() {
+        this.session_id = Date.now();
         this.dialog.close(global.get_current_time());
     }
 


### PR DESCRIPTION
I really wanted to be able to use shellscript to integrate into the launcher, so I took a crack at creating an external launcher extension.

It is pretty well described in the EXTERNALLAUNCHER.md, but in short, I have added a . (dot) prefix, that examines the following word for a matching script or program in $HOME/.pop-shell.launcher/*

If found, it sends list and apply signals to the script, and presents the result.

This is my first try at GJS (and TypeScript), so I am of course fully open to suggestions.
I would really like to be able to integrate with your preview function, and also present proper icons.