### PR TITLE
Fix an error with gnome extension naming scheme

### DIFF
--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -93,7 +93,9 @@ set_keybindings() {
 set_keybindings
 
 # Use a window placement behavior which works better for tiling
-gnome-extensions enable native-window-placement
+
+Gnome_extension_native_windows_placement_name=$(gnome-extensions list | grep "native-window")
+gnome-extensions enable $Gnome_extension_native_windows_placement_name
 
 # Workspaces spanning displays works better with Pop Shell
 dconf write /org/gnome/mutter/workspaces-only-on-primary false


### PR DESCRIPTION
This is a quick fix to avoid the following error :
```
Extension “native-window-placement” does not exist
make: *** [Makefile:27: configure] Error 2
```
Tested in fedora 32 and 33 with gnome 3.36 and 3.38 respectively.