### PR TITLE
feat: make the hint appear much smoother

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1612,6 +1612,7 @@ export class Ext extends Ecs.System<ExtEvent> {
         }
 
         const original = this.active_workspace();
+        this.hide_all_borders();
 
         let tiler = new auto_tiler.AutoTiler(
             new Forest.Forest()

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1582,6 +1582,7 @@ export class Ext extends Ecs.System<ExtEvent> {
     }
 
     auto_tile_off() {
+        this.hide_all_borders();
         if (this.schedule_idle(() => {
             this.auto_tile_off()
             return false
@@ -1604,6 +1605,7 @@ export class Ext extends Ecs.System<ExtEvent> {
     }
 
     auto_tile_on() {
+        this.hide_all_borders();
         if (this.schedule_idle(() => {
             this.auto_tile_on()
             return false;
@@ -1612,7 +1614,6 @@ export class Ext extends Ecs.System<ExtEvent> {
         }
 
         const original = this.active_workspace();
-        this.hide_all_borders();
 
         let tiler = new auto_tiler.AutoTiler(
             new Forest.Forest()
@@ -1650,7 +1651,6 @@ export class Ext extends Ecs.System<ExtEvent> {
 
             return true
         }
-
         return false
     }
 

--- a/src/tiling.ts
+++ b/src/tiling.ts
@@ -330,7 +330,7 @@ export class Tiler {
 
                 ext.auto_tiler.forest.arrange(ext, fork.workspace);
 
-                Tweener.on_window_tweened(window.meta, () => {
+                Tweener.on_window_tweened(window, () => {
                     ext.register_fn(() => ext.set_overlay(window.rect()));
                 });
             }
@@ -338,7 +338,7 @@ export class Tiler {
     }
 
     overlay_watch(ext: Ext, window: window.ShellWindow) {
-        Tweener.on_window_tweened(window.meta, () => {
+        Tweener.on_window_tweened(window, () => {
             ext.register_fn(() => {
                 if (window) {
                     ext.set_overlay(window.rect());

--- a/src/tweener.ts
+++ b/src/tweener.ts
@@ -14,8 +14,11 @@ export interface TweenParams {
 export function add(win: ShellWindow, p: TweenParams) {
     let a = win.meta.get_compositor_private();
     if (!p.mode) p.mode = Clutter.AnimationMode.LINEAR;
-    if (a)
+    if (a) {
+        win.hide_border();
+        win.update_border_layout();
         a.ease(p);
+    }
 }
 
 export function remove(a: Clutter.Actor) {
@@ -30,6 +33,7 @@ export function is_tweening(a: Clutter.Actor) {
 }
 
 export function on_window_tweened(win: ShellWindow, callback: () => void): SignalID {
+    win.update_border_layout();
     win.hide_border();
     return GLib.timeout_add(GLib.PRIORITY_DEFAULT, 100, () => {
         const actor = win.meta.get_compositor_private();

--- a/src/tweener.ts
+++ b/src/tweener.ts
@@ -1,3 +1,5 @@
+import { ShellWindow } from "./window";
+
 const GLib: GLib = imports.gi.GLib;
 const { Clutter } = imports.gi;
 
@@ -9,10 +11,11 @@ export interface TweenParams {
     onComplete?: () => void;
 }
 
-export function add(a: Clutter.Actor, p: TweenParams) {
+export function add(win: ShellWindow, p: TweenParams) {
+    let a = win.meta.get_compositor_private();
     if (!p.mode) p.mode = Clutter.AnimationMode.LINEAR;
-
-    a.ease(p);
+    if (a)
+        a.ease(p);
 }
 
 export function remove(a: Clutter.Actor) {
@@ -23,16 +26,15 @@ export function is_tweening(a: Clutter.Actor) {
     return a.get_transition('x')
         || a.get_transition('y')
         || a.get_transition('scale-x')
-        || a.get_transition('scale-x');
+        || a.get_transition('scale-y');
 }
 
-export function on_window_tweened(meta: Meta.Window, callback: () => void): SignalID {
+export function on_window_tweened(win: ShellWindow, callback: () => void): SignalID {
+    win.hide_border();
     return GLib.timeout_add(GLib.PRIORITY_DEFAULT, 100, () => {
-        const actor = meta.get_compositor_private();
+        const actor = win.meta.get_compositor_private();
         if (actor && is_tweening(actor)) return true;
-
         callback();
-
         return false;
     });
 }
@@ -40,9 +42,7 @@ export function on_window_tweened(meta: Meta.Window, callback: () => void): Sign
 export function on_actor_tweened(actor: Clutter.Actor, callback: () => void): SignalID {
     return GLib.timeout_add(GLib.PRIORITY_DEFAULT, 100, () => {
         if (is_tweening(actor)) return true;
-
         callback();
-
         return false;
     });
 }

--- a/src/window.ts
+++ b/src/window.ts
@@ -269,6 +269,7 @@ export class ShellWindow {
     }
 
     move(ext: Ext, rect: Rectangular, on_complete?: () => void) {
+        this.hide_border();
         const clone = Rect.Rectangle.from_meta(rect);
         const meta = this.meta;
         const actor = meta.get_compositor_private();
@@ -279,9 +280,6 @@ export class ShellWindow {
             meta.unmaximize(Meta.MaximizeFlags.HORIZONTAL | Meta.MaximizeFlags.VERTICAL);
 
             const entity_string = String(this.entity);
-
-            this.hide_border();
-
             ext.movements.insert(this.entity, clone);
 
             const onComplete = () => {
@@ -289,6 +287,7 @@ export class ShellWindow {
                 if (on_complete) ext.register_fn(on_complete);
                 ext.tween_signals.delete(entity_string);
                 if (meta.appears_focused) {
+                    this.update_border_layout();
                     this.show_border();
                 }
             };
@@ -314,10 +313,10 @@ export class ShellWindow {
 
                 const duration = ext.tiler.moving ? 49 : 149;
 
-                Tweener.add(actor, { x, y, duration, mode: null });
+                Tweener.add(this, { x, y, duration, mode: null });
 
                 ext.tween_signals.set(entity_string, [
-                    Tweener.on_window_tweened(meta, onComplete),
+                    Tweener.on_window_tweened(this, onComplete),
                     onComplete
                 ]);
             } else {
@@ -477,36 +476,36 @@ export class ShellWindow {
     }
 
     private update_border_layout() {
-        let frameRect = this.meta.get_frame_rect();
-        let [frameX, frameY, frameWidth, frameHeight] = [frameRect.x, frameRect.y, frameRect.width, frameRect.height];
-
+        let rect = this.meta.get_frame_rect();
         let border = this.border;
         let borderSize = this.border_size;
 
-        if (!this.is_max_screen()) {
-            border.remove_style_class_name('pop-shell-border-maximize');
-        } else {
-            borderSize = 0;
-            border.add_style_class_name('pop-shell-border-maximize');
-        }
-
-        let stack_number = this.stack;
-
-        if (stack_number !== null) {
-            const stack = this.ext.auto_tiler?.forest.stacks.get(stack_number);
-            if (stack) {
-                let stack_tab_height = stack.tabs_height;
-
-                if (borderSize === 0 || this.grab) { // not in max screen state
-                    stack_tab_height = 0;
-                }
-
-                border.set_position(frameX - borderSize, frameY - stack_tab_height - borderSize);
-                border.set_size(frameWidth + 2 * borderSize, frameHeight + stack_tab_height + 2 * borderSize);
+        if (border) {
+            if (!this.is_max_screen()) {
+                border.remove_style_class_name('pop-shell-border-maximize');
+            } else {
+                borderSize = 0;
+                border.add_style_class_name('pop-shell-border-maximize');
             }
-        } else {
-            border.set_position(frameX - borderSize, frameY - borderSize);
-            border.set_size(frameWidth + (2 * borderSize), frameHeight + (2 * borderSize));
+    
+            let stack_number = this.stack;
+    
+            if (stack_number !== null) {
+                const stack = this.ext.auto_tiler?.forest.stacks.get(stack_number);
+                if (stack) {
+                    let stack_tab_height = stack.tabs_height;
+    
+                    if (borderSize === 0 || this.grab) { // not in max screen state
+                        stack_tab_height = 0;
+                    }
+    
+                    border.set_position(rect.x - borderSize, rect.y - stack_tab_height - borderSize);
+                    border.set_size(rect.width + 2 * borderSize, rect.height + stack_tab_height + 2 * borderSize);
+                }
+            } else {
+                border.set_position(rect.x - borderSize, rect.y - borderSize);
+                border.set_size(rect.width + (2 * borderSize), rect.height + (2 * borderSize));
+            }
         }
     }
 

--- a/src/window.ts
+++ b/src/window.ts
@@ -378,14 +378,16 @@ export class ShellWindow {
     }
 
     show_border() {
+        this.restack();
         if (this.ext.settings.active_hint()) {
             let border = this.border;
             if (!this.meta.is_fullscreen() &&
                 !this.meta.minimized &&
                 this.same_workspace()) {
-                border.show();
+                if (this.meta.appears_focused) {
+                    border.show();
+                }
             }
-            this.restack();
         }
     }
 
@@ -403,6 +405,7 @@ export class ShellWindow {
      * @param updateState NORMAL, RAISED, WORKSPACE_CHANGED
      */
     restack(updateState: RESTACK_STATE = RESTACK_STATE.NORMAL) {
+        this.update_border_layout();
         let restackSpeed = RESTACK_SPEED.NORMAL;
 
         switch (updateState) {
@@ -423,6 +426,7 @@ export class ShellWindow {
             let win_group = global.window_group;
 
             if (actor && border && win_group) {
+                this.update_border_layout();
                 // move the border above the window group first
                 win_group.set_child_above_sibling(border, null);
 
@@ -451,8 +455,6 @@ export class ShellWindow {
                     if (!parent_actor && parent_actor !== actor) continue
                     win_group.set_child_below_sibling(border, window_actor)
                 }
-
-                this.update_border_layout();
             }
 
             return false; // make sure it runs once
@@ -469,13 +471,14 @@ export class ShellWindow {
 
         return above_windows;
     }
+    
 
     hide_border() {
         let b = this.border;
         if (b) b.hide();
     }
 
-    private update_border_layout() {
+    update_border_layout() {
         let rect = this.meta.get_frame_rect();
         let border = this.border;
         let borderSize = this.border_size;
@@ -510,8 +513,8 @@ export class ShellWindow {
     }
 
     private window_changed() {
-        this.ext.show_border_on_focused();
         this.update_border_layout();
+        this.show_border();
     }
 
     private window_raised() {


### PR DESCRIPTION
Since the shell is now putting the windows back into their positions pre-tiling, the hint seems to look like being dragged. Need to hide the hint when it is being toggled, or when the tweener is being activated - so the experience is more snappy and smoother.