### PR TITLE
use the hint color for overlay

### DIFF
--- a/dark.css
+++ b/dark.css
@@ -5,6 +5,10 @@
     box-shadow: inset 0 0 0 1px rgba(24, 23, 23, 0)
 }
 
+.pop-shell-overlay {
+    background-color: rgba(53, 132, 228, 0.3);
+}
+
 .pop-shell-border-normal {
     border-width: 3px;
 }

--- a/light.css
+++ b/light.css
@@ -5,6 +5,10 @@
     box-shadow: inset 0 0 0 1px rgba(200, 200, 200, 0);
 }
 
+.pop-shell-overlay {
+    background-color: rgba(53, 132, 228, 0.3);
+}
+
 .pop-shell-border-normal {
     border-width: 3px;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -67,7 +67,7 @@ export class Ext extends Ecs.System<ExtEvent> {
     // Widgets
 
     /** An overlay which shows a preview of where a window will be moved */
-    overlay: Clutter.Actor = new St.BoxLayout({ style_class: "tile-preview", visible: false });
+    overlay: St.Widget = new St.BoxLayout({ style_class: "pop-shell-overlay", visible: false });
 
     /** The application launcher, focus search, and calculator dialog */
     window_search: Launcher = new launcher.Launcher(this);

--- a/src/window.ts
+++ b/src/window.ts
@@ -134,8 +134,7 @@ export class ShellWindow {
         let change_id = settings.ext.connect('changed', (_, key) => {
             if (this.border) {
                 if (key === 'hint-color-rgba') {
-                    let color_value = settings.hint_color_rgba();
-                    this.border.set_style(`border-color: ${color_value}`);
+                    this.update_hint_colors();
                 }
             }
             return false;
@@ -146,8 +145,37 @@ export class ShellWindow {
             this.on_style_changed();
         });
 
-        let selected_color = settings.hint_color_rgba();
-        this.border.set_style(`border-color: ${selected_color}`);
+        this.update_hint_colors();
+    }
+
+    /**
+     * Adjust the colors for: 
+     * - border hint
+     * - overlay
+     */
+    private update_hint_colors() {
+        let settings = this.ext.settings;
+        const color_value = settings.hint_color_rgba();
+
+        if (this.ext.overlay) {
+            const gdk = new Gdk.RGBA();
+            // TODO Probably move overlay color/opacity to prefs.js in future,
+            // For now mimic the hint color with lower opacity
+            const overlay_alpha = 0.3;
+            const orig_overlay = 'rgba(53, 132, 228, 0.3)';
+            gdk.parse(color_value);
+            
+            if (utils.is_dark(gdk.to_string())) {
+                // too dark, use the blue overlay
+                gdk.parse(orig_overlay);
+            }
+
+            gdk.alpha = overlay_alpha
+            this.ext.overlay.set_style(`background: ${gdk.to_string()}`);
+        }
+
+        if (this.border) 
+            this.border.set_style(`border-color: ${color_value}`);
     }
 
     cmdline(): string | null {


### PR DESCRIPTION
I thought it would be nice to have consistency on the accent. Including the overlay.
Would probably be overkill but here goes:

light colored borders, will use .3 opacity with the same color else
for dark colored borders, default to very light blue hint

![image](https://user-images.githubusercontent.com/348125/95280083-2d7cdc80-0822-11eb-94a3-ac51cff482e3.png)

![image](https://user-images.githubusercontent.com/348125/95280107-41284300-0822-11eb-9a0b-896641df65ed.png)
