### PR TITLE
fix flicker tween observer as near realtime

### DIFF
--- a/src/tweener.ts
+++ b/src/tweener.ts
@@ -15,6 +15,7 @@ export function add(win: ShellWindow, p: TweenParams) {
     let a = win.meta.get_compositor_private();
     if (!p.mode) p.mode = Clutter.AnimationMode.LINEAR;
     if (a) {
+        remove(a);
         win.hide_border();
         win.update_border_layout();
         a.ease(p);
@@ -35,10 +36,21 @@ export function is_tweening(a: Clutter.Actor) {
 export function on_window_tweened(win: ShellWindow, callback: () => void): SignalID {
     win.update_border_layout();
     win.hide_border();
-    return GLib.timeout_add(GLib.PRIORITY_DEFAULT, 100, () => {
+
+    // the amount of delay for recursively checking
+    // if the animation is done.
+    const tween_timeout = 20;
+    
+    return GLib.timeout_add(GLib.PRIORITY_DEFAULT, tween_timeout, () => {
         const actor = win.meta.get_compositor_private();
-        if (actor && is_tweening(actor)) return true;
-        callback();
+        if (actor) {
+            if (is_tweening(actor)) {
+                return true;
+            } else {
+                remove(actor);
+                callback();
+            }
+        }
         return false;
     });
 }


### PR DESCRIPTION
Closes #547 

This should fix the flicker due to the higher delay of the tween observer under `on_window_tweened`.
Disabling the whole thing will be worked on a future PR.