### PR TITLE
Add dialog window and apps to the floating list

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -26,6 +26,9 @@ const DEFAULT_RULES: Array<FloatRule> =[
     { class: "KotatogramDesktop", title: "Media viewer" },
     { class: "Steam", title: "^((?!Steam).)*$" },
     { class: "TelegramDesktop", title: "Media viewer" },
+    { class: "Slack", title: "Slack | mini panel" },
+    { class: "Solaar", },
+    { class: "zoom", },
 ]
 
 export interface FloatRule {


### PR DESCRIPTION
Adds three windows/apps:

1. Solaar. Meant to be used as a dialog window. Utility to program Logitech receivers.
2. Zoom. Includes tons of dialog windows that don't tile well.
3. Slack mini panel. PIP mode when on a video call. Designed to float.