### PR TITLE
Don't move always on all workspaces windows

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1294,7 +1294,7 @@ export class Ext extends Ecs.System<ExtEvent> {
         function window_move(ext: Ext, entity: Entity, ws: WorkspaceID) {
             if (change_workspace) {
                 const window = ext.windows.get(entity);
-                if (!window || !window.actor_exists()) return;
+                if (!window || !window.actor_exists() || window.meta.is_on_all_workspaces()) return;
 
                 ext.size_signals_block(window);
                 window.meta.change_workspace_by_index(ws, false);

--- a/src/mod.d.ts
+++ b/src/mod.d.ts
@@ -201,6 +201,7 @@ declare namespace Meta {
         is_above(): boolean;
         is_client_decorated(): boolean;
         is_fullscreen(): boolean;
+        is_on_all_workspaces(): boolean;
         is_skip_taskbar(): boolean;
         make_above(): void;
         make_fullscreen(): void;


### PR DESCRIPTION
While creating an upper workspace, the extension adds a new workspace below and push all the non-selected windows down, and in GNOME, moving a window selected as "Always on Visible Workspace" to another workspace disables that option from the window. This pull request aims to solve that issue.

Steps to reproduce the issue:

1.Open window A and window B on the first workspace you have.
2.Right-click on the window title of the window B and select "Always on Visible Workspace"
3.Select window A, and press Super+Shift+Up to create an upper workspace.
4.You will notice that window A is moved to a new workspace, but window B is not "Always on Visible Workspace" anymore.