### PR TITLE
Use XDG paths where possible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
 # Retrieve the UUID from ``metadata.json``
 UUID = $(shell grep -E '^[ ]*"uuid":' ./metadata.json | sed 's@^[ ]*"uuid":[ ]*"\(.\+\)",[ ]*@\1@')
 
+ifeq ($(XDG_DATA_HOME),)
+XDG_DATA_HOME = $(HOME)/.local/share
+endif
+
 ifeq ($(strip $(DESTDIR)),)
-INSTALLBASE = $(HOME)/.local/share/gnome-shell/extensions
+INSTALLBASE = $(XDG_DATA_HOME)/gnome-shell/extensions
 else
 INSTALLBASE = $(DESTDIR)/usr/share/gnome-shell/extensions
 endif

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ This provides the tiling window manager experience, where windows are automatica
 - Ultra-wide displays are treated as two separate displays by default (**Unimplemented**)
 
 ### Customizing the Floating Window List
-There is file `$HOME/.config/pop-shell/config.json` where you can add the following structure:
+There is file `$XDG_CONFIG_HOME/pop-shell/config.json` where you can add the following structure:
 ```
 {
   class: "<WM_CLASS String from xprop>",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 const { Gio, GLib } = imports.gi;
 
-const CONF_DIR: string = GLib.get_home_dir() + "/.config/pop-shell"
+const CONF_DIR: string = GLib.get_user_config_dir() + "/pop-shell"
 export var CONF_FILE: string = CONF_DIR + "/config.json"
 
 export interface FloatRule {


### PR DESCRIPTION
Minor change to use XDG paths for the configuration file and installing for local development.

Apologies if the commit messages aren't inline with what you use, tried to base them on others, but I wasn't sure how to categorise this change.