### PR TITLE
fix: Add floating exception for system76-driver

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -34,6 +34,7 @@ export const DEFAULT_RULES: Array<FloatRule> = [
     { class: "TelegramDesktop", title: "Media viewer" },
     { class: "Slack", title: "Slack | mini panel" },
     { class: "Solaar", },
+    { class: "system76-driver", },
     { class: "zoom", },
 ];
 


### PR DESCRIPTION
`system76-driver` doesn't support rescaling. I looked at trying to make it resize, but doing it with a layout that doesn't look funny seems difficult. It makes sense for that kind of program to be floating, probably.