### PR TITLE
fix: Windows without a wm_class show now float by default

### DIFF
--- a/src/window.ts
+++ b/src/window.ts
@@ -255,8 +255,10 @@ export class ShellWindow {
                 && this.meta.window_type == Meta.WindowType.NORMAL
                 // Transient windows are most likely dialogs
                 && !this.is_transient()
+                // If a window lacks a class, it's probably an web browser dialog
+                && wm_class !== null
                 // Blacklist any windows that happen to leak through our filter
-                && (wm_class === null || !ext.conf.window_shall_float(wm_class, this.meta.get_title()));
+                && !ext.conf.window_shall_float(wm_class, this.meta.get_title());
         };
 
         return !ext.contains_tag(this.entity, Tags.Floating)


### PR DESCRIPTION
All windows should have a class, and if they don't, there's a good chance we should avoid trying to tile it.

Closes #680 