### PR TITLE
Add GNOME Terminal preferences and DING preferences to floating exceptions

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -36,6 +36,9 @@ export const DEFAULT_RULES: Array<FloatRule> = [
     { class: "Solaar", },
     { class: "system76-driver", },
     { class: "zoom", },
+    { class: "Gnome-terminal", title: "Preferences – General"},
+    { class: "Gjs", title: "Settings"},
+    }
 ];
 
 export interface FloatRule {

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,7 +38,6 @@ export const DEFAULT_RULES: Array<FloatRule> = [
     { class: "zoom", },
     { class: "Gnome-terminal", title: "Preferences – General"},
     { class: "Gjs", title: "Settings"},
-    }
 ];
 
 export interface FloatRule {


### PR DESCRIPTION
Adds two windows to floating exceptions:

- GNOME Termianl preferences (hamburger menu -> Preferences)
- Desktop Icons NG settings (right-click the desktop -> Settings)

Neither of these windows are resizable.