### PR TITLE
Add pop-shell-exceptions to system exceptions

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -36,6 +36,7 @@ export const DEFAULT_RULES: Array<FloatRule> = [
     { class: "Solaar", },
     { class: "system76-driver", },
     { class: "zoom", },
+    { class: "pop-shell-exceptions", },
 ];
 
 export interface FloatRule {


### PR DESCRIPTION
This commit adds the "Floating Window Exceptions" window on Wayland to system exceptions.
This is needed because while it is floating by default on Xorg, it is not on Wayland.

Closes #690.