### PR TITLE
Override terminal launch shortcut to be in line with others

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ These are key to many of the shortcuts utilized by tiling window managers. This 
 - `Super` + `f`: Files
 - `Super` + `e`: Email
 - `Super` + `b`: Web Browser
+- `Super` + `t`: Terminal
 
 ### Window Management Mode
 

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -83,6 +83,8 @@ set_keybindings() {
     dconf write ${KEYS_MEDIA}/email "['<Super>e']"
     # Launch web browser
     dconf write ${KEYS_MEDIA}/www "['<Super>b']"
+    # Launch terminal
+    dconf write ${KEYS_MEDIA}/terminal "['<Super>t']"
     # Rotate Video Lock
     dconf write ${KEYS_MEDIA}/rotate-video-lock-static "@as []"
 


### PR DESCRIPTION
Before this change, terminal seemed to be the only shortcut not being overridden (at least on default Ubuntu 20.10) from the Keyboard Shortcuts > Launchers section and used Ctrl+Alt+T instead of Super+T.

This change aims to make things a bit more consistent and hopefully facilitate transition from other desktop environments (like Xfce).

Tested with `make local-install` and seems to be working correctly.