### PR TITLE
Window being selected too soon from exceptions select

### DIFF
--- a/src/dialog_add_exception.ts
+++ b/src/dialog_add_exception.ts
@@ -61,7 +61,7 @@ export class AddExceptionDialog {
     }
 
     show() {
-        this.dialog.show_all();
+        this.dialog.show();
     }
 
     open() {

--- a/src/mod.d.ts
+++ b/src/mod.d.ts
@@ -42,6 +42,7 @@ declare interface GLib {
 
     find_program_in_path(prog: string): string | null;
     get_current_dir(): string;
+    get_monotonic_time(): number;
 
     idle_add(priority: any, callback: () => boolean): number;
 


### PR DESCRIPTION
Sometimes the exceptions dialog selects a window immediately after the overview opens