### PR TITLE
Window being selected too soon from exceptions select

### DIFF
--- a/src/dialog_add_exception.ts
+++ b/src/dialog_add_exception.ts
@@ -61,7 +61,7 @@ export class AddExceptionDialog {
     }
 
     show() {
-        this.dialog.show_all();
+        this.dialog.show();
     }
 
     open() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,6 +46,7 @@ const Tags = Me.imports.tags;
 
 const STYLESHEET_PATHS = ['light', 'dark'].map(stylesheet_path);
 const STYLESHEETS = STYLESHEET_PATHS.map((path) => Gio.File.new_for_path(path));
+const GNOME_VERSION = utils.gnome_version()
 
 enum Style { Light, Dark }
 
@@ -516,9 +517,20 @@ export class Ext extends Ecs.System<ExtEvent> {
     }
 
     exception_select() {
-        log.debug('select a window plz')
-        overview.show()
-        this.exception_selecting = true;
+        if (GNOME_VERSION?.startsWith("3.36")) {
+            // 3.36 required a delay to work
+            GLib.timeout_add(GLib.PRIORITY_LOW, 500, () => {
+                this.exception_selecting = true
+                overview.show()
+                return false
+            })
+        } else {
+            GLib.idle_add(GLib.PRIORITY_LOW, () => {
+                this.exception_selecting = true
+                overview.show()
+                return false
+            })
+        }
     }
 
     exit_modes() {
@@ -653,7 +665,7 @@ export class Ext extends Ecs.System<ExtEvent> {
         this.size_signals_unblock(win);
 
         if (this.exception_selecting) {
-            this.exception_add(win);
+            this.exception_add(win)
         }
 
         // Keep the last-focused window from being shifted too quickly. 300ms debounce

--- a/src/mod.d.ts
+++ b/src/mod.d.ts
@@ -42,6 +42,7 @@ declare interface GLib {
 
     find_program_in_path(prog: string): string | null;
     get_current_dir(): string;
+    get_monotonic_time(): number;
 
     idle_add(priority: any, callback: () => boolean): number;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -136,3 +136,10 @@ export function async_process_ipc(argv: Array<string>): AsyncIPC | null {
 
     return { stdin, stdout }
 }
+
+export function gnome_version(): null | string {
+    let [,out] = GLib.spawn_command_line_sync("gnome-shell --version");
+    if (!out) return null;
+
+    return imports.byteArray.toString(out).split(' ')[2]
+}


### PR DESCRIPTION
Sometimes the exceptions dialog selects a window immediately after the overview opens