### PR TITLE
fix: Tab disconnect sometimes tries to disconnect undefined tab

### DIFF
--- a/src/stack.ts
+++ b/src/stack.ts
@@ -587,7 +587,8 @@ export class Stack {
         if (window && window.actor_exists()) {
             func(window)
         } else {
-            this.tab_disconnect(this.tabs[comp])
+            const tab = this.tabs[comp]
+            if (tab) this.tab_disconnect(tab)
         }
     }
 }


### PR DESCRIPTION
I've occasionally run into a scenario where this codepath is hit with an `undefined` tab. This causes the stack to get stuck without an active window.