### PR TITLE
Install schemas system-wide, and install Gnome Control Center keybindings xml files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ restart-shell:
 
 update-repository:
 	git fetch origin
-	git reset --hard origin/master_focal
+	git reset --hard origin/master
 	git clean -fd
 
 schemas: schemas/gschemas.compiled

--- a/debian/control
+++ b/debian/control
@@ -12,4 +12,6 @@ Architecture: all
 Depends:
     ${misc:Depends},
     pop-shell-shortcuts
+Replaces: gnome-control-center-data (<< 1:3.38.1-2ubuntu1pop1~)
+Breaks: gnome-control-center-data (<< 1:3.38.1-2ubuntu1pop1~)
 Description: Pop!_OS Shell

--- a/debian/pop-shell.install
+++ b/debian/pop-shell.install
@@ -1,0 +1,1 @@
+schemas/org.gnome.shell.extensions.pop-shell.gschema.xml usr/share/glib-2.0/schemas

--- a/debian/pop-shell.install
+++ b/debian/pop-shell.install
@@ -1,1 +1,2 @@
 schemas/org.gnome.shell.extensions.pop-shell.gschema.xml usr/share/glib-2.0/schemas
+keybindings/*.xml usr/share/gnome-control-center/keybindings

--- a/debian/rules
+++ b/debian/rules
@@ -4,5 +4,11 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
+BASEDIR=debian/pop-shell/usr/share/gnome-shell/extensions/pop-shell@system76.com
+
 %:
 	dh $@
+
+override_dh_install:
+	dh_install
+	rm -rf $(BASEDIR)/schemas

--- a/keybindings/10-pop-shell-move.xml
+++ b/keybindings/10-pop-shell-move.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<KeyListEntries group="system" schema="org.gnome.shell.extensions.pop-shell" name="Move, resize, and swap windows">
+  <KeyListEntry name="tile-accept" description="Apply changes"/>
+  <KeyListEntry name="tile-enter" description="Adjustment mode"/>
+  <KeyListEntry name="tile-move-down" description="Move window down"/>
+  <KeyListEntry name="tile-move-left" description="Move window left"/>
+  <KeyListEntry name="tile-move-right" description="Move window right"/>
+  <KeyListEntry name="tile-move-up" description="Move window up"/>
+  <KeyListEntry name="tile-reject" description="Cancel changes"/>
+  <KeyListEntry name="tile-resize-left" description="Resize window smaller"/>
+  <KeyListEntry name="tile-resize-right" description="Resize window larger"/>
+  <KeyListEntry name="tile-resize-up" description="Resize window shorter"/>
+  <KeyListEntry name="tile-resize-down" description="Resize window taller"/>
+  <KeyListEntry name="tile-swap-down" description="Swap window down"/>
+  <KeyListEntry name="tile-swap-left" description="Swap window left"/>
+  <KeyListEntry name="tile-swap-right" description="Swap window right"/>
+  <KeyListEntry name="tile-swap-up" description="Swap window up"/>
+  <KeyListEntry name="management-orientation" description="Change current window orientation"/>
+</KeyListEntries>

--- a/keybindings/10-pop-shell-navigate.xml
+++ b/keybindings/10-pop-shell-navigate.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<KeyListEntries group="system" schema="org.gnome.shell.extensions.pop-shell" name="Navigate applications and windows">
+  <KeyListEntry name="activate-launcher" description="Launch and switch applications"/>
+  <KeyListEntry name="focus-down" description="Switch focus to window down"/>
+  <KeyListEntry name="focus-left" description="Switch focus to window left"/>
+  <KeyListEntry name="focus-right" description="Switch focus to window right"/>
+  <KeyListEntry name="focus-up" description="Switch focus to window up"/>
+</KeyListEntries>

--- a/keybindings/10-pop-shell-tile.xml
+++ b/keybindings/10-pop-shell-tile.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<KeyListEntries group="system" schema="org.gnome.shell.extensions.pop-shell" name="Tiling">
+  <KeyListEntry name="tile-orientation" description="Change window orientation"/>
+  <KeyListEntry name="toggle-floating" description="Toggles a window between floating and tiling"/>
+  <KeyListEntry name="toggle-tiling" description="Toggles auto-tiling"/>
+</KeyListEntries>


### PR DESCRIPTION
See commit messages for detailed explanation and justification. This eliminates the need to patch `gnome-control-center` for `pop-shell`. Updates to the keybindings can be made without having interdependencies between pop-shell and `gnome-control-center` packages (after this one).

This should make several things easier and avoid certain problems.

Requires corresponding change to focal/groovy `gnome-control-center` package.