### PR TITLE
fix(keybindings): Add missing bindings

### DIFF
--- a/keybindings/10-pop-shell-move.xml
+++ b/keybindings/10-pop-shell-move.xml
@@ -6,6 +6,12 @@
   <KeyListEntry name="tile-move-left" description="Move window left"/>
   <KeyListEntry name="tile-move-right" description="Move window right"/>
   <KeyListEntry name="tile-move-up" description="Move window up"/>
+  <KeyListEntry name="pop-workspace-down" description="Move window to lower workspace"/>
+  <KeyListEntry name="pop-workspace-up" description="Move window to upper workspace"/>
+  <KeyListEntry name="pop-monitor-down" description="Move window to lower monitor"/>
+  <KeyListEntry name="pop-monitor-left" description="move window to leftward monitor"/>
+  <KeyListEntry name="pop-monitor-right" description="move window to rightward monitor"/>
+  <KeyListEntry name="pop-monitor-up" description="Move window to upper monitor"/>
   <KeyListEntry name="tile-reject" description="Cancel changes"/>
   <KeyListEntry name="tile-resize-left" description="Resize window smaller"/>
   <KeyListEntry name="tile-resize-right" description="Resize window larger"/>

--- a/keybindings/10-pop-shell-tile.xml
+++ b/keybindings/10-pop-shell-tile.xml
@@ -3,4 +3,6 @@
   <KeyListEntry name="tile-orientation" description="Change window orientation"/>
   <KeyListEntry name="toggle-floating" description="Toggles a window between floating and tiling"/>
   <KeyListEntry name="toggle-tiling" description="Toggles auto-tiling"/>
+  <KeyListEntry name="toggle-stacking" description="Toggle stacking mode inside management mode"/>
+  <KeyListEntry name="toggle-stacking-global" description="Toggle stacking mode outside management mode"/>
 </KeyListEntries>


### PR DESCRIPTION
These were added to focal in https://github.com/pop-os/gnome-control-center/commit/f667803fc93c41bb7dad1ace13abc018c151531d but never made it into the groovy package.