### PR TITLE
fix: Handle regression in 3.38.2 backports that caused nautilus to resize without moving

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -253,6 +253,7 @@ export class Ext extends Ecs.System<ExtEvent> {
                     const { x, y, width, height } = movement;
 
                     window.meta.move_resize_frame(true, x, y, width, height);
+                    window.meta.move_frame(true, x, y)
 
                     this.monitors.insert(window.entity, [
                         win.meta.get_monitor(),

--- a/src/mod.d.ts
+++ b/src/mod.d.ts
@@ -206,6 +206,7 @@ declare namespace Meta {
         make_above(): void;
         make_fullscreen(): void;
         maximize(flags: MaximizeFlags): void;
+        move_frame(user_op: boolean, x: number, y: number): void;
         move_resize_frame(user_op: boolean, x: number, y: number, w: number, h: number): boolean;
         raise(): void;
         unmake_fullscreen(): void;


### PR DESCRIPTION
Although we can also wait to see if the 3.38.2 release has fixed the problem.