### PR TITLE
Check for gnome-extensions in Makefile depcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,11 +56,11 @@ depcheck:
 		echo 'You must install TypeScript >= 3.8 to transpile: (node-typescript on Debian systems)'; \
 		exit 1; \
 	fi
-        @if ! command -v gnome-extensions >/dev/null; then \
-                echo \
-                echo 'You must install gnome-extensions to configure or enable via this script (`gnome-shell` on Debian systems, `gnome-extensions` on openSUSE systems.)'; \
-                exit 1; \
-        fi
+	@if ! command -v gnome-extensions >/dev/null; then \
+		echo \
+		echo 'You must install gnome-extensions to configure or enable via this script (`gnome-shell` on Debian systems, `gnome-extensions` on openSUSE systems.)'; \
+		exit 1; \
+	fi
 
 enable:
 	gnome-extensions enable "pop-shell@system76.com"

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,11 @@ depcheck:
 		echo 'You must install TypeScript >= 3.8 to transpile: (node-typescript on Debian systems)'; \
 		exit 1; \
 	fi
+        @if ! command -v gnome-extensions >/dev/null; then \
+                echo \
+                echo 'You must install gnome-extensions to configure or enable via this script (`gnome-shell` on Debian systems, `gnome-extensions` on openSUSE systems.)'; \
+                exit 1; \
+        fi
 
 enable:
 	gnome-extensions enable "pop-shell@system76.com"

--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,8 @@ depcheck:
 		exit 1; \
 	fi
 	@if ! command -v gnome-extensions >/dev/null; then \
-		echo \
-		echo 'You must install gnome-extensions to configure or enable via this script (`gnome-shell` on Debian systems, `gnome-extensions` on openSUSE systems.)'; \
+		echo 'You must install gnome-extensions to configure or enable via this script ' \
+		'(gnome-shell` on Debian systems, `gnome-extensions` on openSUSE systems.)'; \
 		exit 1; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ depcheck:
 	fi
 	@if ! command -v gnome-extensions >/dev/null; then \
 		echo 'You must install gnome-extensions to configure or enable via this script' \
-		'(gnome-shell` on Debian systems, `gnome-extensions` on openSUSE systems.)'; \
+		'(`gnome-shell` on Debian systems, `gnome-extensions` on openSUSE systems.)'; \
 		exit 1; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ depcheck:
 		exit 1; \
 	fi
 	@if ! command -v gnome-extensions >/dev/null; then \
-		echo 'You must install gnome-extensions to configure or enable via this script ' \
+		echo 'You must install gnome-extensions to configure or enable via this script' \
 		'(gnome-shell` on Debian systems, `gnome-extensions` on openSUSE systems.)'; \
 		exit 1; \
 	fi


### PR DESCRIPTION
`gnome-extensions` is a separate package from `gnome-shell` on some systems (e.g. openSUSE), so when running operations that require it, check if it's present and show the package name if not. If someone doesn't want to install `gnome-extensions`, it's still possible to compile, install, and configure manually using those individual operations.

Closes #767.