### PR TITLE
Add Sideload app to default floating exceptions.

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -41,6 +41,7 @@ export const DEFAULT_RULES: Array<FloatRule> = [
     { class: "zoom", },
     { class: "Gnome-terminal", title: "Preferences – General" },
     { class: "Gjs", title: "Settings" },
+    { class: "Io.elementary.sideload", },
 ];
 
 export interface FloatRule {


### PR DESCRIPTION
The new Sideload app to install .flatpakref files (added with https://github.com/pop-os/desktop/pull/58 and https://github.com/pop-os/desktop/pull/59) does not currently resize and should be floated by default.