### PR TITLE
fix: update order of steps for local-install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ disable:
 listen:
 	journalctl -o cat -n 0 -f "$$(which gnome-shell)" | grep -v warning
 
-local-install: depcheck compile install configure enable restart-shell
+local-install: depcheck compile install configure restart-shell enable
 
 install:
 	rm -rf $(INSTALLBASE)/$(INSTALLNAME)
@@ -92,6 +92,7 @@ restart-shell:
 	else \
 		gnome-session-quit --logout; \
 	fi
+	sleep 3
 
 update-repository:
 	git fetch origin


### PR DESCRIPTION
Fixes #760 #703 

New install of ext using source if none exists.
Existing should still work.

Wayland - need to still logout/login.

Note: `sleep 3` was added because the `gnome-extensions enable` command was being executed prior to `Meta.eval` resolves to restart the shell. If there is another elegant way, I am happy to update the PR.