### PR TITLE
fix: Disable window animations for tile arrangements

### DIFF
--- a/src/forest.ts
+++ b/src/forest.ts
@@ -869,5 +869,5 @@ function move_window(ext: Ext, window: ShellWindow, rect: Rectangular, on_comple
     window.move(ext, rect, () => {
         on_complete();
         ext.size_signals_unblock(window);
-    });
+    }, false);
 }

--- a/src/window.ts
+++ b/src/window.ts
@@ -274,7 +274,7 @@ export class ShellWindow {
         return xid ? xprop.may_decorate(xid) : false;
     }
 
-    move(ext: Ext, rect: Rectangular, on_complete?: () => void) {
+    move(ext: Ext, rect: Rectangular, on_complete?: () => void, animate: boolean = true) {
         if ((!this.same_workspace() && this.is_maximized())) {
             return
         }
@@ -302,7 +302,7 @@ export class ShellWindow {
                 }
             };
 
-            if (ext.animate_windows && !ext.init) {
+            if (animate && ext.animate_windows && !ext.init) {
                 const current = meta.get_frame_rect();
                 const buffer = meta.get_buffer_rect();
 


### PR DESCRIPTION
They cause a lot of issues with no clear solution.

Closes #780 
Fixes blurry windows