### PR TITLE
feat(tiling): Recheck tiling exceptions on window title change

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -850,7 +850,7 @@ export class Ext extends Ecs.System<ExtEvent> {
     on_grab_end(meta: Meta.Window, op?: any) {
         let win = this.get_window(meta);
 
-        if (null === win || !win.is_tilable(this)) {
+        if (null === win || !win.is_tilable(this) || this.contains_tag(win.entity, Tags.Floating)) {
             return;
         }
 
@@ -1691,14 +1691,6 @@ export class Ext extends Ecs.System<ExtEvent> {
         }
 
         return matched;
-    }
-
-    * tiled_windows(): IterableIterator<Entity> {
-        for (const entity of this.entities()) {
-            if (this.contains_tag(entity, Tags.Tiled)) {
-                yield entity;
-            }
-        }
     }
 
     toggle_tiling() {

--- a/src/tags.ts
+++ b/src/tags.ts
@@ -1,4 +1,3 @@
-export var Tiled = 0;
 export var Floating = 1;
 export var Blocked = 2;
 export var ForceTile = 3;

--- a/src/tiling.ts
+++ b/src/tiling.ts
@@ -647,10 +647,8 @@ export class Tiler {
 
                 if (!tree_swapped) {
                     ext.size_signals_block(meta);
-                    const meta_entity = this.window;
                     meta.move(ext, ext.overlay, () => {
                         ext.size_signals_unblock(meta);
-                        ext.add_tag(meta_entity, Tags.Tiled);
                     });
                 }
             }


### PR DESCRIPTION
Fixes exceptions for windows that change their titles dynamically after initialization