### PR TITLE
fix(tiling): Prevent moving pointer if pointer is already in window

### DIFF
--- a/src/window.ts
+++ b/src/window.ts
@@ -535,16 +535,9 @@ export class ShellWindow {
     private window_raised() {
         this.restack(RESTACK_STATE.RAISED);
         this.show_border();
-        if (this.ext.conf.move_pointer_on_switch && !this.pointer_already_on_window()) {
+        if (this.ext.conf.move_pointer_on_switch && !pointer_already_on_window(this.meta)) {
             place_pointer_on(this.ext.conf.default_pointer_position, this.meta);
         }
-    }
-
-    private pointer_already_on_window(): boolean {
-        const rect = Rect.Rectangle.from_meta(this.meta.get_frame_rect());
-        const cursor = lib.cursor_rect();
-
-        return cursor.intersects(rect);
     }
 
     private workspace_changed() {
@@ -557,7 +550,10 @@ export function activate(default_pointer_position: Config.DefaultPointerPosition
     win.raise();
     win.unminimize();
     win.activate(global.get_current_time());
-    place_pointer_on(default_pointer_position, win)
+
+    if (!pointer_already_on_window(win)) {
+        place_pointer_on(default_pointer_position, win)
+    }
 }
 
 export function place_pointer_on(default_pointer_position: Config.DefaultPointerPosition, win: Meta.Window) {
@@ -597,4 +593,11 @@ export function place_pointer_on(default_pointer_position: Config.DefaultPointer
         .get_default_seat()
         .get_pointer()
         .warp(display.get_default_screen(), x, y);
+}
+
+function pointer_already_on_window(meta: Meta.Window): boolean {
+    const rect = Rect.Rectangle.from_meta(meta.get_frame_rect());
+    const cursor = lib.cursor_rect();
+
+    return cursor.intersects(rect);
 }


### PR DESCRIPTION
This is useful for stopping a pointer from continually moving back to the top left in a stacked arrangement

Closes #792 