### PR TITLE
Feat: Support Horizontal Workspaces

### DIFF
--- a/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
@@ -197,6 +197,16 @@
             <summary>Move window to the upper workspace</summary>
         </key>
 
+        <key type="as" name="pop-workspace-right">
+            <default><![CDATA[['<Control><Shift><Alt>Right']]]></default>
+            <summary>Move window to workspace on the right</summary>
+        </key>
+
+        <key type="as" name="pop-workspace-left">
+            <default><![CDATA[['<Control><Shift><Alt>Left']]]></default>
+            <summary>Move window to workspace on the left</summary>
+        </key>
+
         <key type="as" name="pop-monitor-down">
             <default><![CDATA[['<Super><Shift><Primary>Down','<Super><Shift><Primary>j']]]></default>
             <summary>Move window to the lower monitor</summary>

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -46,10 +46,6 @@ set_keybindings() {
     dconf write ${KEYS_GNOME_SHELL}/toggle-message-tray "@as ['<Super>v']"
     # Show the activities overview: disable <Super>s
     dconf write ${KEYS_GNOME_SHELL}/toggle-overview "@as []"
-    # Switch to workspace left: disable <Super>Left
-    dconf write ${KEYS_GNOME_WM}/switch-to-workspace-left "@as []"
-    # Switch to workspace right: disable <Super>Right
-    dconf write ${KEYS_GNOME_WM}/switch-to-workspace-right "@as []"
     # Maximize window: disable <Super>Up
     dconf write ${KEYS_GNOME_WM}/maximize "@as []"
     # Restore window: disable <Super>Down
@@ -68,12 +64,20 @@ set_keybindings() {
     dconf write ${KEYS_GNOME_WM}/move-to-workspace-up "@as []"
     # Move window one monitor to the right
     dconf write ${KEYS_GNOME_WM}/move-to-monitor-right "@as []"
+    # Move window one workspace left
+    dconf write ${KEYS_GNOME_WM}/move-to-workspace-left "@as []"
+    # Move window one workspace right
+    dconf write ${KEYS_GNOME_WM}/move-to-workspace-right "@as []"
 
     # Super + Ctrl + direction keys, change workspaces, move focus between monitors
     # Move to workspace below
     dconf write ${KEYS_GNOME_WM}/switch-to-workspace-down "['<Primary><Super>Down','<Primary><Super>${down}']"
     # Move to workspace above
     dconf write ${KEYS_GNOME_WM}/switch-to-workspace-up "['<Primary><Super>Up','<Primary><Super>${up}']"
+    # Switch to workspace left (default keys from Gnome 3.38)
+    dconf write ${KEYS_GNOME_WM}/switch-to-workspace-left "['<Control><Alt>Left']"
+    # Switch to workspace right
+    dconf write ${KEYS_GNOME_WM}/switch-to-workspace-right "['<Control><Alt>Right']"
 
     # Disable tiling to left / right of screen
     dconf write ${KEYS_MUTTER}/toggle-tiled-left "@as []"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1046,13 +1046,13 @@ export class Ext extends Ecs.System<ExtEvent> {
 
             if (neighbor && neighbor.index() !== ws.index()) {
                 move_to_neighbor(neighbor);
-            } else if (direction === Meta.MotionDirection.DOWN && !last_window()) {
+            } else if ((direction === Meta.MotionDirection.DOWN || direction === Meta.MotionDirection.RIGHT) && !last_window()) {
                 if (this.settings.dynamic_workspaces()) {
                     neighbor = wom.append_new_workspace(false, global.get_current_time());
                 } else {
                     return;
                 }
-            } else if (direction === Meta.MotionDirection.UP && ws.index() === 0) {
+            } else if ((direction === Meta.MotionDirection.UP || direction === Meta.MotionDirection.LEFT) && ws.index() === 0) {
                 if (this.settings.dynamic_workspaces()) {
                     // Add a new workspace, to push everyone to free up the first one
                     wom.append_new_workspace(false, global.get_current_time());
@@ -1089,6 +1089,14 @@ export class Ext extends Ecs.System<ExtEvent> {
 
             case Meta.DisplayDirection.UP:
                 workspace_move(Meta.MotionDirection.UP)
+                break;
+
+            case Meta.DisplayDirection.RIGHT:
+                workspace_move(Meta.MotionDirection.RIGHT)
+                break;
+
+            case Meta.DisplayDirection.LEFT:
+                workspace_move(Meta.MotionDirection.LEFT)
                 break;
         }
 

--- a/src/keybindings.ts
+++ b/src/keybindings.ts
@@ -69,7 +69,11 @@ export class Keybindings {
 
             "pop-workspace-up": () => ext.move_workspace(Meta.DisplayDirection.UP),
 
-            "pop-workspace-down": () => ext.move_workspace(Meta.DisplayDirection.DOWN)
+            "pop-workspace-down": () => ext.move_workspace(Meta.DisplayDirection.DOWN),
+
+            "pop-workspace-left": () => ext.move_workspace(Meta.DisplayDirection.LEFT),
+
+            "pop-workspace-right": () => ext.move_workspace(Meta.DisplayDirection.RIGHT)
         };
     }
 


### PR DESCRIPTION
close: #308
Notes
 - The code was already flexible enough to support this, therefore, this can be seen as minor tweak
 - Kept the workspace switching and window placing keys to the default in Gnome 3.38
 - Maybe it's code for the future, since Gnome 40 will be using a horizontal layout