### PR TITLE
fix(app-specific): Firefox has a rendering issue on some systems that requires some jiggling

### DIFF
--- a/src/auto_tiler.ts
+++ b/src/auto_tiler.ts
@@ -181,6 +181,20 @@ export class AutoTiler {
             id = [id[0], 0]
         }
 
+        // NOTE: Firefox has a rendering heisenbug. Jiggle it after tiling.
+        if (win.meta.get_wm_class()?.includes("Firefox")) {
+            const { GLib, Meta } = imports.gi;
+
+            GLib.timeout_add(GLib.PRIORITY_DEFAULT, 500, () => {
+                const flags = Meta.MaximizeFlags.HORIZONTAL | Meta.MaximizeFlags.VERTICAL
+                win.meta.maximize(flags)
+
+                GLib.timeout_add(GLib.PRIORITY_DEFAULT, 500, () => {
+                    win.meta.unmaximize(flags)
+                })
+            })
+        }
+
         const toplevel = this.forest.find_toplevel(id);
 
         if (toplevel) {

--- a/src/window.ts
+++ b/src/window.ts
@@ -109,7 +109,6 @@ export class ShellWindow {
 
         if (this.meta.get_compositor_private()?.get_stage())
             this.on_style_changed();
-
     }
 
     activate(): void {


### PR DESCRIPTION
While not an issue with Pop Shell directly, Firefox encounters a rendering issue some systems when the window is opened and resized . Unsure on a way to detect when Firefox has misrendered, but this will add a check for Firefox that will maximize and unmaximize the window if it's attached to an empty workspace.

Closes #388