### PR TITLE
feat: Change orientation with mouse & show overlay hint on drag

### DIFF
--- a/src/fork.ts
+++ b/src/fork.ts
@@ -340,6 +340,15 @@ export class Fork {
         }
     }
 
+    /** Swaps the left branch with the right branch, if there is a right branch */
+    swap_branches() {
+        if (this.right) {
+            const temp = this.left
+            this.left = this.right
+            this.right = temp
+        }
+    }
+
     /** Toggles the orientation of this fork */
     toggle_orientation() {
         this.orientation = Lib.Orientation.HORIZONTAL === this.orientation

--- a/src/geom.ts
+++ b/src/geom.ts
@@ -1,3 +1,10 @@
+export enum Side {
+    LEFT,
+    TOP,
+    RIGHT,
+    BOTTOM
+}
+
 export function xend(rect: Rectangular): number {
     return rect.x + rect.width;
 }
@@ -60,6 +67,24 @@ export function downward_distance(win_a: Meta.Window, win_b: Meta.Window) {
 
 export function leftward_distance(win_a: Meta.Window, win_b: Meta.Window) {
     return directional_distance(win_a.get_frame_rect(), win_b.get_frame_rect(), east, west);
+}
+
+export function nearest_side(origin: [number, number], rect: Rectangular): [number, Side] {
+    const left = east(rect), top = north(rect), right = west(rect), bottom = south(rect)
+
+    const left_distance = distance(origin, left),
+        top_distance = distance(origin, top),
+        right_distance = distance(origin, right),
+        bottom_distance = distance(origin, bottom)
+
+    let nearest: [number, Side] = left_distance < right_distance
+        ? [left_distance, Side.LEFT]
+        : [right_distance, Side.RIGHT]
+
+    if (top_distance < nearest[0]) nearest = [top_distance, Side.TOP]
+    if (bottom_distance < nearest[0]) nearest = [bottom_distance, Side.BOTTOM]
+
+    return nearest
 }
 
 export function shortest_side(origin: [number, number], rect: Rectangular): number {

--- a/src/tiling.ts
+++ b/src/tiling.ts
@@ -427,6 +427,11 @@ export class Tiler {
                     const [stack_fork, branch,] = stack_info;
                     const stack = branch.inner as NodeStack;
 
+                    const placement = {
+                        cursor: Lib.cursor_rect(),
+                        area: Rect.Rectangle.from_meta(move_to.meta.get_frame_rect())
+                    }
+
                     focused.ignore_detach = true;
                     at.detach_window(ext, focused.entity);
 
@@ -437,7 +442,7 @@ export class Tiler {
 
                     focused.ignore_detach = true;
                     at.detach_window(ext, focused.entity);
-                    at.attach_to_window(ext, move_to, focused, { cursor: Lib.cursor_rect() }, stack_from_left);
+                    at.attach_to_window(ext, move_to, focused, placement, stack_from_left);
                     watching = focused;
                 } else {
                     const parent = at.windows_are_siblings(focused.entity, move_to.entity);


### PR DESCRIPTION
When dragging a window, an overlay will be shown indicating where the window will be placed in the tree on drop.
This will make it intuitive to set the tiling orientation on drop of a window, rather than requiring a keyboard

Closes #829 