### PR TITLE
feat: Support numpad in default keybindings

### DIFF
--- a/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
@@ -50,22 +50,22 @@
 
         <!-- Focus Shifting -->
         <key type="as" name="focus-left">
-            <default><![CDATA[['<Super>Left','<Super>h']]]></default>
+            <default><![CDATA[['<Super>Left','<Super>KP_Left','<Super>h']]]></default>
             <summary>Focus left window</summary>
         </key>
 
         <key type="as" name="focus-down">
-            <default><![CDATA[['<Super>Down','<Super>j']]]></default>
+            <default><![CDATA[['<Super>Down','<Super>KP_Down','<Super>j']]]></default>
             <summary>Focus down window</summary>
         </key>
 
         <key type="as" name="focus-up">
-            <default><![CDATA[['<Super>Up','<Super>k']]]></default>
+            <default><![CDATA[['<Super>Up','<Super>KP_Up','<Super>k']]]></default>
             <summary>Focus up window</summary>
         </key>
 
         <key type="as" name="focus-right">
-            <default><![CDATA[['<Super>Right','<Super>l']]]></default>
+            <default><![CDATA[['<Super>Right','<Super>KP_Right','<Super>l']]]></default>
             <summary>Focus right window</summary>
         </key>
 
@@ -92,12 +92,12 @@
         </key>
 
         <key type="as" name="tile-enter">
-            <default><![CDATA[['<Super>Return']]]></default>
+            <default><![CDATA[['<Super>Return','<Super>KP_Enter']]]></default>
             <summary>Enter tiling mode</summary>
         </key>
 
         <key type="as" name="tile-accept">
-            <default><![CDATA[['Return']]]></default>
+            <default><![CDATA[['Return','KP_Enter']]]></default>
             <summary>Accept tiling changes</summary>
         </key>
 
@@ -119,22 +119,22 @@
 
 
         <key type="as" name="tile-move-left">
-            <default><![CDATA[['Left','h']]]></default>
+            <default><![CDATA[['Left','KP_Left','h']]]></default>
             <summary>Move window left</summary>
         </key>
 
         <key type="as" name="tile-move-down">
-            <default><![CDATA[['Down','j']]]></default>
+            <default><![CDATA[['Down','KP_Down','j']]]></default>
             <summary>Move window down</summary>
         </key>
 
         <key type="as" name="tile-move-up">
-            <default><![CDATA[['Up','k']]]></default>
+            <default><![CDATA[['Up','KP_Up','k']]]></default>
             <summary>Move window up</summary>
         </key>
 
         <key type="as" name="tile-move-right">
-            <default><![CDATA[['Right','l']]]></default>
+            <default><![CDATA[['Right','KP_Right','l']]]></default>
             <summary>Move window right</summary>
         </key>
 
@@ -145,75 +145,75 @@
 
         <!-- Resize in normal direction -->
         <key type="as" name="tile-resize-left">
-            <default><![CDATA[['<Shift>Left','<Shift>h']]]></default>
+            <default><![CDATA[['<Shift>Left','<Shift>KP_Left','<Shift>h']]]></default>
             <summary>Resize window left</summary>
         </key>
 
         <key type="as" name="tile-resize-down">
-            <default><![CDATA[['<Shift>Down','<Shift>j']]]></default>
+            <default><![CDATA[['<Shift>Down','<Shift>KP_Down','<Shift>j']]]></default>
             <summary>Resize window down</summary>
         </key>
 
         <key type="as" name="tile-resize-up">
-            <default><![CDATA[['<Shift>Up','<Shift>k']]]></default>
+            <default><![CDATA[['<Shift>Up','<Shift>KP_Up','<Shift>k']]]></default>
             <summary>Resize window up</summary>
         </key>
 
         <key type="as" name="tile-resize-right">
-            <default><![CDATA[['<Shift>Right','<Shift>l']]]></default>
+            <default><![CDATA[['<Shift>Right','<Shift>KP_Right','<Shift>l']]]></default>
             <summary>Resize window right</summary>
         </key>
 
         <!-- Swap windows -->
         <key type="as" name="tile-swap-left">
-            <default><![CDATA[['<Primary>Left','<Primary>h']]]></default>
+            <default><![CDATA[['<Primary>Left','<Primary>KP_Left','<Primary>h']]]></default>
             <summary>Swap window left</summary>
         </key>
 
         <key type="as" name="tile-swap-down">
-            <default><![CDATA[['<Primary>Down','<Primary>j']]]></default>
+            <default><![CDATA[['<Primary>Down','<Primary>KP_Down','<Primary>j']]]></default>
             <summary>Swap window down</summary>
         </key>
 
         <key type="as" name="tile-swap-up">
-            <default><![CDATA[['<Primary>Up','<Primary>k']]]></default>
+            <default><![CDATA[['<Primary>Up','<Primary>KP_Up','<Primary>k']]]></default>
             <summary>Swap window up</summary>
         </key>
 
         <key type="as" name="tile-swap-right">
-            <default><![CDATA[['<Primary>Right','<Primary>l']]]></default>
+            <default><![CDATA[['<Primary>Right','<Primary>KP_Right','<Primary>l']]]></default>
             <summary>Swap window right</summary>
         </key>
 
         <!-- Workspace Management -->
 
         <key type="as" name="pop-workspace-down">
-            <default><![CDATA[['<Super><Shift>Down','<Super><Shift>j']]]></default>
+            <default><![CDATA[['<Super><Shift>Down','<Super><Shift>KP_Down','<Super><Shift>j']]]></default>
             <summary>Move window to the lower workspace</summary>
         </key>
 
         <key type="as" name="pop-workspace-up">
-            <default><![CDATA[['<Super><Shift>Up','<Super><Shift>k']]]></default>
+            <default><![CDATA[['<Super><Shift>Up','<Super><Shift>KP_Up','<Super><Shift>k']]]></default>
             <summary>Move window to the upper workspace</summary>
         </key>
 
         <key type="as" name="pop-monitor-down">
-            <default><![CDATA[['<Super><Shift><Primary>Down','<Super><Shift><Primary>j']]]></default>
+            <default><![CDATA[['<Super><Shift><Primary>Down','<Super><Shift><Primary>KP_Down','<Super><Shift><Primary>j']]]></default>
             <summary>Move window to the lower monitor</summary>
         </key>
 
         <key type="as" name="pop-monitor-up">
-            <default><![CDATA[['<Super><Shift><Primary>Up','<Super><Shift><Primary>k']]]></default>
+            <default><![CDATA[['<Super><Shift><Primary>Up','<Super><Shift><Primary>KP_Up','<Super><Shift><Primary>k']]]></default>
             <summary>Move window to the upper monitor</summary>
         </key>
 
         <key type="as" name="pop-monitor-left">
-            <default><![CDATA[['<Super><Shift>Left','<Super><Shift>h']]]></default>
+            <default><![CDATA[['<Super><Shift>Left','<Super><Shift>KP_Left','<Super><Shift>h']]]></default>
             <summary>Move window to the leftward monitor</summary>
         </key>
 
         <key type="as" name="pop-monitor-right">
-            <default><![CDATA[['<Super><Shift>Right','<Super><Shift>l']]]></default>
+            <default><![CDATA[['<Super><Shift>Right','<Super><Shift>KP_Right','<Super><Shift>l']]]></default>
             <summary>Move window to the rightward monitor</summary>
         </key>
 


### PR DESCRIPTION
Keys on the numpad are considered distinct, but users seem to expect them to work the same way. (See recent discussion on  Mattermost.)

I opened an issue with Mutter suggesting these could be treated equally there: https://gitlab.gnome.org/GNOME/mutter/-/issues/1631

Alternately we could not make a change here, and instead patch Mutter. But I'm included to wait to see what upstream Gnome thinks of that. The only disadvantage I can think of to this change is a bit more clutter in Gnome Control Center when listing bindings.