### PR TITLE
fix: Mouse dropping from stack to adjacent sibling

### DIFF
--- a/src/auto_tiler.ts
+++ b/src/auto_tiler.ts
@@ -456,7 +456,7 @@ export class AutoTiler {
                         return true
                     }
                 }
-            } else if (is_sibling) {
+            } else if (is_sibling && win.stack === null) {
                 swap(placement.orientation, direction)
                 return true
             } else if (fork.is_toplevel && fork.right === null) {


### PR DESCRIPTION
If you have three windows, and two are stacked, moving a window from the stack to attach to the adjacent window will now work instead of swapping positions.