### PR TITLE
fix: Don't show border on maximized windows

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -779,7 +779,7 @@ export class Ext extends Ecs.System<ExtEvent> {
 
         const focus = this.focus_window();
         if (focus) {
-            focus.show_border();
+            focus.update_border_state();
         }
     }
 

--- a/src/window.ts
+++ b/src/window.ts
@@ -301,7 +301,7 @@ export class ShellWindow {
                 ext.tween_signals.delete(entity_string);
                 if (meta.appears_focused) {
                     this.update_border_layout();
-                    this.show_border();
+                    this.update_border_state();
                 }
             };
 
@@ -390,16 +390,19 @@ export class ShellWindow {
         })
     }
 
-    show_border() {
+    update_border_state() {
         this.restack();
         if (this.ext.settings.active_hint()) {
             let border = this.border;
             if (!this.meta.is_fullscreen() &&
+                !this.is_maximized() &&
                 !this.meta.minimized &&
-                this.same_workspace()) {
-                if (this.meta.appears_focused) {
+                this.same_workspace() &&
+                this.meta.appears_focused) {
                     border.show();
-                }
+            }
+            else {
+                border.hide();
             }
         }
     }
@@ -532,12 +535,12 @@ export class ShellWindow {
 
     private window_changed() {
         this.update_border_layout();
-        this.show_border();
+        this.update_border_state();
     }
 
     private window_raised() {
         this.restack(RESTACK_STATE.RAISED);
-        this.show_border();
+        this.update_border_state();
         if (this.ext.conf.move_pointer_on_switch && !pointer_already_on_window(this.meta)) {
             place_pointer_on(this.ext.conf.default_pointer_position, this.meta);
         }


### PR DESCRIPTION
Hide the active hint border on maximized windows. 

Applying a border to a maximized window is not helpful unless multiple monitors are being used. Even on multi-monitor setups, applying a border to a maximized window is more distracting than helpful to me, though that may be a matter of opinion.