### PR TITLE
Add DEV Community to websearch

### DIFF
--- a/src/plugins/web/main.js
+++ b/src/plugins/web/main.js
@@ -23,7 +23,8 @@ const ENTRIES = new Map([
     ['lib', { query: 'https://libraries.io/search?q=', name: 'Libraries.io' }],
     ['gist', { query: 'https://gist.github.com/search?q=', name: 'GitHub Gist' }],
     ['fh', { query: 'https://flathub.org/apps/search/', name: 'flathub' }],
-    ['gh', { query: 'https://github.com/search?q=', name: 'github' }]
+    ['gh', { query: 'https://github.com/search?q=', name: 'github' }],
+    ['dev', { query: 'https://dev.to/search?q=', name: 'DEV Community' }]
 ])
 
 class App {

--- a/src/plugins/web/meta.json
+++ b/src/plugins/web/meta.json
@@ -1,7 +1,7 @@
 {
     "name": "Web Search",
     "description": "Searches",
-    "pattern": "^(amazon|wiki|bing|ddg|google|yt|stack|crates|arch|pp|ppw|rdt|bc|lib|npm|gist|fh|gh)\\s.*",
+    "pattern": "^(amazon|wiki|bing|ddg|google|yt|stack|crates|arch|pp|ppw|rdt|bc|lib|npm|gist|fh|gh|dev)\\s.*",
     "exec": "main.js",
     "icon": "system-search"
 }


### PR DESCRIPTION
The DEV Community is really useful to have in the websearch plugin.

For the keyword, I wasn't sure between `dev` or `devto`, but this can be changed anyway. 
