### PR TITLE
<Alt>F4 keybinding should be preserved

### DIFF
--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -95,7 +95,7 @@ set_keybindings() {
     dconf write ${KEYS_MEDIA}/rotate-video-lock-static "@as []"
 
     # Close Window
-    dconf write ${KEYS_GNOME_WM}/close "['<Super>q']"
+    dconf write ${KEYS_GNOME_WM}/close "['<Super>q', '<Alt>F4']"
 }
 
 set_keybindings


### PR DESCRIPTION
I think it's better to preserve the familiar and popular <Alt>F4 shortcut. 

Thank for all your work and this extension :1st_place_medal: