### PR TITLE
feat: Add support for tab navigation for the launcher

### DIFF
--- a/src/dialog_launcher.ts
+++ b/src/dialog_launcher.ts
@@ -223,14 +223,16 @@ export class Launcher extends search.Search {
             return false
         };
 
-        let complete = () => {
+        let complete = (): boolean => {
             if (this.last_plugin) {
                 plugins.Plugin.complete(ext, this.last_plugin)
                 const res = plugins.Plugin.listen(this.last_plugin)
                 if (res && res.event === "fill") {
                     this.set_text(res.text)
+                    return true
                 }
             }
+            return false
         }
 
         super(cancel, search, complete, select, apply);
@@ -244,6 +246,11 @@ export class Launcher extends search.Search {
         this.options = new Array()
         this.desktop_apps = new Array();
         this.mode = -1;
+    }
+
+    clear(){
+        super.clear();
+        this.last_plugin = null;
     }
 
     load_desktop_files() {

--- a/src/dialog_search.ts
+++ b/src/dialog_search.ts
@@ -25,13 +25,13 @@ export class Search {
 
     private apply_cb: (index: number) => boolean;
     private cancel_cb: () => void;
-    private complete_cb: () => void;
+    private complete_cb: () => boolean;
     private select_cb: (id: number) => void;
 
     constructor(
         cancel: () => void,
         search: (pattern: string) => Array<SearchOption> | null,
-        complete: () => void,
+        complete: () => boolean,
         select: (id: number) => void,
         apply: (index: number) => boolean,
     ) {
@@ -78,20 +78,23 @@ export class Search {
                 cancel();
                 return;
             } else if (c === 65289) {
-                this.complete_cb()
+                // Tab was pressed, check for tab completion
+                if(this.complete_cb()){
+                    return;
+                }
             }
 
             let s = event.get_state();
-            if (c == 65362 || (s == Clutter.ModifierType.CONTROL_MASK && c == 107) || (s == Clutter.ModifierType.CONTROL_MASK && c == 112)) {
-                // Up arrow was pressed
+            if (c == 65362 || c == 65056 || (s == Clutter.ModifierType.CONTROL_MASK && c == 107) || (s == Clutter.ModifierType.CONTROL_MASK && c == 112)) {
+                // Up arrow or left tab was pressed
                 if (0 < this.active_id) {
                     this.select_id(this.active_id - 1)
                 }
                 else if (this.active_id == 0) {
                     this.select_id(this.widgets.length - 1)
                 }
-            } else if (c == 65364 || (s == Clutter.ModifierType.CONTROL_MASK && c == 106) || (s == Clutter.ModifierType.CONTROL_MASK && c == 110)) {
-                // Down arrow was pressed
+            } else if (c == 65364 || c == 65289 || (s == Clutter.ModifierType.CONTROL_MASK && c == 106) || (s == Clutter.ModifierType.CONTROL_MASK && c == 110)) {
+                // Down arrow or tab was pressed
                 if (this.active_id + 1 < this.widgets.length) {
                     this.select_id(this.active_id + 1)
                 }


### PR DESCRIPTION
This allow the use of the tab key to navigate between the launcher proposed choices, like in most launcher I know (gnome, rofi, dmenu…). This PR don't conflict with the tab completion of plugins. However, I find the behavior of the file plugin very weird since it complete to path that are not on the top of the list. In terminals and vim tab completion is triggered when it's the only choice possible. 

I would suggest rethinking tab completion, or maybe add a setting to choose the tab key behavior.

Cheers :clap: 