### PR TITLE
fix: auto raise behavior in tiling mode

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -764,7 +764,7 @@ export class Ext extends Ecs.System<ExtEvent> {
         }
 
         // Update the active tab in the stack.
-        if (null !== win.stack) {
+        if (null !== this.auto_tiler && null !== win.stack) {
             ext?.auto_tiler?.forest.stacks.get(win.stack)?.activate(win.entity)
         }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -763,13 +763,9 @@ export class Ext extends Ecs.System<ExtEvent> {
             this.last_focused = win.entity;
         }
 
-        if (null !== this.auto_tiler) {
-            win.meta.raise();
-
-            // Update the active tab in the stack.
-            if (null !== win.stack) {
-                ext?.auto_tiler?.forest.stacks.get(win.stack)?.activate(win.entity)
-            }
+        // Update the active tab in the stack.
+        if (null !== win.stack) {
+            ext?.auto_tiler?.forest.stacks.get(win.stack)?.activate(win.entity)
         }
 
         this.show_border_on_focused();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -765,6 +765,7 @@ export class Ext extends Ecs.System<ExtEvent> {
 
         // Update the active tab in the stack.
         if (null !== this.auto_tiler && null !== win.stack) {
+            win.meta.raise();
             ext?.auto_tiler?.forest.stacks.get(win.stack)?.activate(win.entity)
         }
 


### PR DESCRIPTION
This fixes #627: in tiling mode windows got raised on hover, even if the option in gnome-tweaks was disabled.