### PR TITLE
Dev Rollup

### DIFF
--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -98,6 +98,12 @@ set_keybindings() {
     dconf write ${KEYS_GNOME_WM}/close "['<Super>q', '<Alt>F4']"
 }
 
+if ! command -v gnome-extensions >/dev/null; then
+    echo 'You must install gnome-extensions to configure or enable via this script'
+    '(`gnome-shell` on Debian systems, `gnome-extensions` on openSUSE systems.)'
+    exit 1
+fi
+
 set_keybindings
 
 # Use a window placement behavior which works better for tiling

--- a/scripts/transpile.sh
+++ b/scripts/transpile.sh
@@ -1,12 +1,40 @@
 #!/bin/sh
+set -ex
 
-for file in $(find target -name '*.js'); do
-    sed -i \
-        -e 's#export function#function#g' \
+pwd=$(pwd)
+
+# In goes standard JS. Out comes GJS-compatible JS
+transpile() {
+    cat ${src} | sed -e 's#export function#function#g' \
         -e 's#export var#var#g' \
         -e 's#export const#var#g' \
         -e 's#Object.defineProperty(exports, "__esModule", { value: true });#var exports = {};#g' \
-        "${file}"
-    sed -i -E 's/export class (\w+)/var \1 = class \1/g' "${file}"
-    sed -i -E "s/import \* as (\w+) from '(\w+)'/const \1 = Me.imports.\2/g" "${file}"
+        | sed -E 's/export class (\w+)/var \1 = class \1/g' \
+        | sed -E "s/import \* as (\w+) from '(\w+)'/const \1 = Me.imports.\2/g" > ${dest}
+}
+
+rm -rf _build
+
+glib-compile-schemas schemas &
+
+# Transpile to JavaScript
+
+for proj in ${PROJECTS}; do
+    mkdir -p _build/${proj}
+    tsc --p src/${proj} &
 done
+
+tsc &
+
+wait
+
+# Convert JS to GJS-compatible scripts
+
+cp -r metadata.json icons schemas *.css _build &
+
+for src in $(find target -name '*.js'); do
+    dest=$(echo $src | sed s#target#_build#g)
+    transpile &
+done
+
+wait

--- a/src/app_info.ts
+++ b/src/app_info.ts
@@ -47,6 +47,12 @@ export class AppInfo {
         return this.app_info.filename;
     }
 
+    id(): string {
+        let name = this.filename
+        name = name.substr(0, name.lastIndexOf('.'))
+        return name.substr(name.lastIndexOf('/') + 1)
+    }
+
     categories(): string {
         return this.categories_.get_or_init(() => this.app_info.get_categories());
     }

--- a/src/color_dialog/tsconfig.json
+++ b/src/color_dialog/tsconfig.json
@@ -10,8 +10,6 @@
             "es2015"
         ],
         "pretty": true,
-        "sourceMap": true,
-        "declaration": true,
         "removeComments": true,
         "incremental": true,
         "noUnusedLocals": true,

--- a/src/dedicated_gpu.ts
+++ b/src/dedicated_gpu.ts
@@ -1,0 +1,46 @@
+import type { AppInfo } from './app_info'
+
+const { Shell, St } = imports.gi;
+const AppDisplay = imports.ui.appDisplay;
+
+const PopupMenu = imports.ui.popupMenu
+const Main = imports.ui.main
+
+const appSys = Shell.AppSystem.get_default()
+
+export function addPopup(info: AppInfo, widget: any) {
+    // GNOME Shell already tracks if a discrete GPU is available.
+    // We will only add a popup if one is available.
+    if (!AppDisplay.discreteGpuAvailable) return
+
+    const menu = new PopupMenu.PopupMenu(widget, 0.0, St.Side.TOP, 0)
+    Main.uiGroup.add_actor(menu.actor)
+    menu.actor.hide()
+    menu.actor.add_style_class_name('panel-menu');
+
+    const appPrefersNonDefaultGPU = info.app_info.get_boolean('PrefersNonDefaultGPU');
+    const gpuPref = appPrefersNonDefaultGPU
+        ? Shell.AppLaunchGpu.DEFAULT
+        : Shell.AppLaunchGpu.DISCRETE;
+
+    const menu_item = appendMenuItem(menu, appPrefersNonDefaultGPU
+        ? _('Launch using Integrated Graphics Card')
+        : _('Launch using Discrete Graphics Card'));
+
+    menu_item.connect('activate', () => {
+        appSys.lookup_desktop_wmclass(info.id())?.launch(0, -1, gpuPref)
+    });
+
+    // Intercept right click events on the launcher app's button
+    widget.connect('button-press-event', (_: any, event: any) => {
+        if (event.get_button() === 3) {
+            menu.toggle()
+        }
+    })
+}
+
+function appendMenuItem(menu: any, label: string) {
+    let item = new PopupMenu.PopupMenuItem(label);
+    menu.addMenuItem(item);
+    return item
+}

--- a/src/dialog_launcher.ts
+++ b/src/dialog_launcher.ts
@@ -157,7 +157,7 @@ export class Launcher extends search.Search {
             this.options = windows.concat(this.options)
 
             // Truncate excess items from the list
-            this.options.splice(this.list_max());
+            this.options.splice(this.list_max);
 
             return this.options;
         };
@@ -312,7 +312,7 @@ export class Launcher extends search.Search {
         for (const window of ext.tab_list(Meta.TabList.NORMAL, null)) {
             if (show_all_workspaces || window.workspace_id() === active) {
                 this.options.push(window_selection(ext, window, this.icon_size()))
-                if (this.options.length == this.list_max()) break;
+                if (this.options.length == this.list_max) break;
             }
         }
     }

--- a/src/dialog_launcher.ts
+++ b/src/dialog_launcher.ts
@@ -1,21 +1,21 @@
 //@ts-ignore
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 
-const { Clutter, Gio, GLib, Meta } = imports.gi;
-
 import * as app_info from 'app_info';
 import * as error from 'error';
+import * as launch from 'launcher_service';
+import * as levenshtein from 'levenshtein';
 import * as lib from 'lib';
 import * as log from 'log';
+import * as plugins from 'launcher_plugins';
 import * as result from 'result';
 import * as search from 'dialog_search';
-import * as launch from 'launcher_service';
-import * as plugins from 'launcher_plugins';
-import * as levenshtein from 'levenshtein';
 
-import type { ShellWindow } from 'window';
-import type { Ext } from 'extension';
 import type { AppInfo } from 'app_info';
+import type { Ext } from 'extension';
+import type { ShellWindow } from 'window';
+
+const { Clutter, Gio, GLib, Meta } = imports.gi
 
 const { OK } = result;
 
@@ -42,7 +42,7 @@ export class Launcher extends search.Search {
     desktop_apps: Array<[string, AppInfo]>
     service: launch.LauncherService
     last_plugin: null | plugins.Plugin.Source
-    mode: number;
+    mode: number
 
     constructor(ext: Ext) {
         let cancel = () => {
@@ -114,14 +114,16 @@ export class Launcher extends search.Search {
                 if (retain) {
                     const generic = app.generic_name();
 
-                    this.options.push(new launch.SearchOption(
+                    const button = new launch.SearchOption(
                         app.name(),
                         generic ? generic + " — " + where : where,
                         'application-default-symbolic',
                         { gicon: app.icon() },
                         this.icon_size(),
                         { app }
-                    ))
+                    )
+
+                    this.options.push(button)
                 }
             }
 

--- a/src/dialog_launcher.ts
+++ b/src/dialog_launcher.ts
@@ -3,6 +3,7 @@ const Me = imports.misc.extensionUtils.getCurrentExtension();
 
 import * as app_info from 'app_info';
 import * as error from 'error';
+import * as DedicatedGPU from 'dedicated_gpu';
 import * as launch from 'launcher_service';
 import * as levenshtein from 'levenshtein';
 import * as lib from 'lib';
@@ -122,6 +123,8 @@ export class Launcher extends search.Search {
                         this.icon_size(),
                         { app }
                     )
+
+                    DedicatedGPU.addPopup(app, button.widget)
 
                     this.options.push(button)
                 }

--- a/src/dialog_search.ts
+++ b/src/dialog_search.ts
@@ -238,9 +238,7 @@ export class Search {
         return 34;
     }
 
-    list_max() {
-        return 9;
-    }
+    get list_max() { return 7 }
 
     reset() {
         this.clear();

--- a/src/floating_exceptions/tsconfig.json
+++ b/src/floating_exceptions/tsconfig.json
@@ -10,8 +10,6 @@
             "es2015"
         ],
         "pretty": true,
-        "sourceMap": true,
-        "declaration": true,
         "removeComments": true,
         "incremental": true,
     },

--- a/src/fork.ts
+++ b/src/fork.ts
@@ -212,7 +212,9 @@ export class Fork {
         area: Rectangle,
         record: (win: Entity, parent: Entity, area: Rectangle) => void
     ) {
-        let ratio;
+        let ratio = null
+
+        let manually_moved = ext.grab_op !== null || ext.tiler.resizing_window
 
         if (!this.is_toplevel) {
             if (this.orientation_changed) {
@@ -229,7 +231,10 @@ export class Fork {
         }
 
         if (ratio) {
-            this.length_left = Math.round(ratio * this.length());
+            this.length_left = Math.round(ratio * this.length())
+            if (manually_moved) this.prev_ratio = ratio
+        } else if (manually_moved) {
+            this.prev_ratio = this.length_left / this.length()
         }
 
         if (this.right) {

--- a/src/launcher_service.ts
+++ b/src/launcher_service.ts
@@ -130,7 +130,7 @@ export class LauncherService {
                 yield plugin
             }
         }
-        
+
         for (const plugin of this.plugins.values()) {
             if (!plugin.pattern || plugin.pattern.test(query)) {
                 yield plugin

--- a/src/scripts/session-reboot.sh
+++ b/src/scripts/session-reboot.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 #
-# name: Reboot
+# name: Restart
 # icon: system-restart
-# description: Restart the system
+# description: Reboot the system
 # keywords: power reboot restart
 
 gnome-session-quit --reboot

--- a/src/scripts/session-shutdown.sh
+++ b/src/scripts/session-shutdown.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 #
-# name: Shut Down
+# name: Power off
 # icon: system-shutdown
-# description: Power off the system
+# description: Shut down the system
 # keywords: power off shutdown
 
 gnome-session-quit --power-off

--- a/src/tiling.ts
+++ b/src/tiling.ts
@@ -37,6 +37,7 @@ export class Tiler {
     window: Entity | null = null;
 
     moving: boolean = false;
+    resizing_window: boolean = false;
 
     private swap_window: Entity | null = null;
 
@@ -616,6 +617,7 @@ export class Tiler {
 
     resize(ext: Ext, direction: Direction) {
         if (!this.window) return;
+        this.resizing_window = true
 
         if (ext.auto_tiler && !ext.contains_tag(this.window, Tags.Floating)) {
             this.resize_auto(ext, direction);
@@ -643,6 +645,8 @@ export class Tiler {
                     .change(ext.overlay, rect, 0, 0, 0, 0);
             });
         }
+
+        this.resizing_window = false
     }
 
     swap(ext: Ext, selector: window.ShellWindow | null) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,6 @@
             "es2015"
         ],
         "pretty": true,
-        "sourceMap": true,
-        "declaration": true,
         "removeComments": true,
         "incremental": true,
         "noUnusedLocals": true,


### PR DESCRIPTION
Promising results with handling display hotplugging and replugging.

- Fixes inconsistent naming of session options in launcher
- Updates trees after unlocking the session from a screen lock
- Fixes tiling layouts getting reset to 50/50 for the top fork when workspaces are removed, or any other change that might have caused a relayout
- Fixes to the way trees are shuffled around on hotplugging of displays
- Trees now remember the last display they were on. If a display is replugged, it will be moved back to its original display. Although this depends on Mutter assigning the same number to the display when it is replugged. Unfortunately, monitors do not get assigned a unique ID in Mutter.

Closes #973 ✅
Closes #964 ✅
May Close #960
Closes #957 ❔
Closes #948 
May Close #934 
Closes #880 
May Close #831 (don't have HiDPI to test with)
~~Closes #794~~ ❌
Closes #980 
Closes #978 
Closes #976 
Closes #979 