### PR TITLE
Check keywords when searching apps

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -88,6 +88,10 @@ Tasks for a tester to verify when approving a patch. Use complex window layouts 
 - [ ] t: executes a command in a terminal
 - [ ] : executes a command in sh
 - [ ] = calculates an equation
+- [ ] Search results are as expected:
+    - `cal` returns Calendar and Calculator before Color
+    - `pops` returns Popsicle first
+    - `shop` returns the Pop!_Shop first
 
 ### Window Titles
 

--- a/src/dialog_launcher.ts
+++ b/src/dialog_launcher.ts
@@ -109,44 +109,30 @@ export class Launcher extends search.Search {
             // Filter matching desktop apps
             for (const [where, app] of this.desktop_apps) {
                 const name = app.name()
-                const name_match = name.toLowerCase()
+                const keywords = app.keywords()
+                const app_items = keywords !== null ? name.split().concat(keywords) : [name]
                 
-                let retain = false
-                if ( name_match.startsWith(pattern)
-                     || name_match.includes(pattern)
-                     || levenshtein.compare(name_match, pattern) < 3 {
-                    retain = true
-                } else if app.keywords() {
-                    for (const keyword of app.keywords()) {
-                        const keyword_match = keyword.toLowerCase()
-                        if ( keyword_match.startsWith(pattern)
-                             || keyword_match.includes(pattern)
-                             || levenshtein.compare(keyword_match, pattern) < 3) {
-                            retain = true
-                        }
+                for (const item of app_items) {
+                    const item_match = item.toLowerCase()
+                    if ( item_match.startsWith(pattern)
+                         || item_match.includes(pattern)
+                         || levenshtein.compare(item_match, pattern) < 3 {
+                        const generic = app.generic_name();
+                        const button = new launch.SearchOption(
+                            name,
+                            generic ? generic + " — " + where : where,
+                            'application-default-symbolic',
+                            { gicon: app.icon() },
+                            this.icon_size(),
+                            { app },
+                            keywords
+                        )
+
+                        DedicatedGPU.addPopup(app, button.widget)
+
+                        this.options.push(button)
+                        break
                     }
-                }
-                
-                if (retain) {
-                    const generic = app.generic_name();
-                    let keywords = "";
-                    if app.keywords() {
-                        keywords = app.keywords();
-                    }
-
-                    const button = new launch.SearchOption(
-                        name,
-                        generic ? generic + " — " + where : where,
-                        'application-default-symbolic',
-                        { gicon: app.icon() },
-                        this.icon_size(),
-                        { app },
-                        keywords
-                    )
-
-                    DedicatedGPU.addPopup(app, button.widget)
-
-                    this.options.push(button)
                 }
             }
 

--- a/src/dialog_launcher.ts
+++ b/src/dialog_launcher.ts
@@ -110,10 +110,23 @@ export class Launcher extends search.Search {
             for (const [where, app] of this.desktop_apps) {
                 const name = app.name()
                 const name_match = name.toLowerCase()
-                const retain = name_match.startsWith(pattern)
-                    || name_match.includes(pattern)
-                    || levenshtein.compare(name_match, pattern) < 3
-
+                
+                let retain = false
+                if ( name_match.startsWith(pattern)
+                     || name_match.includes(pattern)
+                     || levenshtein.compare(name_match, pattern) < 3 {
+                    retain = true
+                } else if app.keywords() {
+                    for (const keyword of app.keywords()) {
+                        const keyword_match = keyword.toLowerCase()
+                        if ( keyword_match.startsWith(pattern)
+                             || keyword_match.includes(pattern)
+                             || levenshtein.compare(keyword_match, pattern) < 3) {
+                            retain = true
+                        }
+                    }
+                }
+                
                 if (retain) {
                     const generic = app.generic_name();
 

--- a/src/launcher_service.ts
+++ b/src/launcher_service.ts
@@ -178,17 +178,17 @@ export class SearchOption {
     title: string
     description: null | string
     id: Identity
+    keywords: null | array
 
     widget: St.Button
 
     shortcut: St.Widget = new St.Label({ text: "", y_align: Clutter.ActorAlign.CENTER, style: "padding-left: 6px;padding-right: 6px" })
-    
-    keywords: null | array
 
     constructor(title: string, description: null | string, category_icon: string, icon: null | IconSrc, icon_size: number, id: Identity, keywords: null | array) {
         this.title = title
         this.description = description
         this.id = id
+        this.keywords = keywords
 
         let cat_icon
         const cat_icon_file = Gio.File.new_for_path(category_icon)
@@ -262,9 +262,5 @@ export class SearchOption {
 
         this.widget = new St.Button({ style_class: "pop-shell-search-element" });
         (this.widget as any).add_actor(layout)
-        
-        if (keywords) {
-            this.keywords = keywords
-        }
     }
 }

--- a/src/launcher_service.ts
+++ b/src/launcher_service.ts
@@ -182,8 +182,10 @@ export class SearchOption {
     widget: St.Button
 
     shortcut: St.Widget = new St.Label({ text: "", y_align: Clutter.ActorAlign.CENTER, style: "padding-left: 6px;padding-right: 6px" })
+    
+    keywords: null | array
 
-    constructor(title: string, description: null | string, category_icon: string, icon: null | IconSrc, icon_size: number, id: Identity) {
+    constructor(title: string, description: null | string, category_icon: string, icon: null | IconSrc, icon_size: number, id: Identity, keywords: null | array) {
         this.title = title
         this.description = description
         this.id = id
@@ -260,5 +262,9 @@ export class SearchOption {
 
         this.widget = new St.Button({ style_class: "pop-shell-search-element" });
         (this.widget as any).add_actor(layout)
+        
+        if (keywords) {
+            this.keywords = keywords
+        }
     }
 }


### PR DESCRIPTION
This is working, but since the sorting algorithm doesn't take keywords into account yet, sometimes results are being sorted lower than they should be.

![Screenshot from 2021-06-16 20-37-56](https://user-images.githubusercontent.com/7199422/122290516-10200800-ceb1-11eb-91bb-2d45a468d177.png)

While working on this, I'm being conscious not to cause a regression with `cal` returning the Color control panel before Calculator or Calendar.