### PR TITLE
fix: Don't use last_focused state in handling notify::focus-window

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1746,7 +1746,7 @@ export class Ext extends Ecs.System<ExtEvent> {
             if (screenShield?.locked) this.update_display_configuration(false);
 
             this.connect(display, 'notify::focus-window', () => {
-                const window = this.focus_window()
+                const window = this.get_window(display.get_focus_window())                
                 if (window) this.on_focused(window)
                 return false
             });


### PR DESCRIPTION
Fixes #712

The solution is based on comments made by @sitepodmatt in https://github.com/pop-os/shell/issues/712#issuecomment-808702391 about the root cause of the issue.

This solution ignores last_focused state in handling notify::focus-window event.