### PR TITLE
fix(active-hint): bug fixes and feature max state hint

### DIFF
--- a/src/mod.d.ts
+++ b/src/mod.d.ts
@@ -153,9 +153,9 @@ declare namespace Meta {
     }
 
     enum MaximizeFlags {
-        HORIZONTAL,
-        VERTICAL,
-        BOTH
+        HORIZONTAL = 1,
+        VERTICAL = 2,
+        BOTH = 3
     }
 
     enum MotionDirection {
@@ -187,6 +187,7 @@ declare namespace Meta {
         delete(timestamp: number): void;
         get_buffer_rect(): Rectangular;
         get_compositor_private(): Clutter.Actor | null;
+        get_display(): Meta.Display | null;
         get_description(): string;
         get_frame_rect(): Rectangular;
         get_maximized(): number;

--- a/src/window.ts
+++ b/src/window.ts
@@ -562,8 +562,6 @@ export class ShellWindow {
                 const screen = workspace.get_work_area_for_monitor(this.meta.get_monitor())
 
                 if (screen) {
-                    x = Math.max(x, screen.x)
-                    y = Math.max(y, screen.y)
                     width = Math.min(width, screen.x + screen.width)
                     height = Math.min(height, screen.y + screen.height)
                 }

--- a/src/window.ts
+++ b/src/window.ts
@@ -238,7 +238,7 @@ export class ShellWindow {
     }
 
     is_maximized(): boolean {
-        let maximized = this.meta.get_maximized() === 3;
+        let maximized = this.meta.get_maximized() == Meta.MaximizeFlags.BOTH;
         return maximized;
     }
 

--- a/src/window.ts
+++ b/src/window.ts
@@ -402,7 +402,7 @@ export class ShellWindow {
             let border = this.border;
             let monitor_count = this.meta.get_display().get_n_monitors();
             if (!this.meta.is_fullscreen() &&
-                !(this.is_maximized() && monitor_count == 1) &&
+                !(this.is_max_screen() && monitor_count == 1) &&
                 !this.meta.minimized &&
                 this.same_workspace()) {
                 if (this.meta.appears_focused) {
@@ -428,7 +428,9 @@ export class ShellWindow {
     restack(updateState: RESTACK_STATE = RESTACK_STATE.NORMAL) {
         this.update_border_layout();
         let monitor_count = this.meta.get_display().get_n_monitors();
-        if (this.meta.is_fullscreen() || (this.is_max_screen() && monitor_count == 1)) {
+        if (this.meta.is_fullscreen() || 
+            (this.is_max_screen() && monitor_count == 1) || 
+            this.meta.minimized) {
             this.hide_border()
         }
 

--- a/src/window.ts
+++ b/src/window.ts
@@ -238,7 +238,8 @@ export class ShellWindow {
     }
 
     is_maximized(): boolean {
-        return this.meta.get_maximized() !== 0;
+        let maximized = this.meta.get_maximized() === 3;
+        return maximized;
     }
 
     /**
@@ -399,7 +400,9 @@ export class ShellWindow {
         this.restack();
         if (this.ext.settings.active_hint()) {
             let border = this.border;
+            let monitor_count = this.meta.get_display().get_n_monitors();
             if (!this.meta.is_fullscreen() &&
+                !(this.is_maximized() && monitor_count == 1) &&
                 !this.meta.minimized &&
                 this.same_workspace()) {
                 if (this.meta.appears_focused) {
@@ -424,8 +427,8 @@ export class ShellWindow {
      */
     restack(updateState: RESTACK_STATE = RESTACK_STATE.NORMAL) {
         this.update_border_layout();
-
-        if (this.meta.is_fullscreen()) {
+        let monitor_count = this.meta.get_display().get_n_monitors();
+        if (this.meta.is_fullscreen() || (this.is_max_screen() && monitor_count == 1)) {
             this.hide_border()
         }
 

--- a/src/window.ts
+++ b/src/window.ts
@@ -254,7 +254,7 @@ export class ShellWindow {
 
     is_single_max_screen(): boolean {
         let monitor_count = this.meta.get_display().get_n_monitors();
-        return this.is_max_screen() && monitor_count == 1;
+        return (this.is_maximized() || this.smart_gapped) && monitor_count == 1;
     }
 
     is_snap_edge(): boolean {

--- a/src/window.ts
+++ b/src/window.ts
@@ -238,7 +238,7 @@ export class ShellWindow {
     }
 
     is_maximized(): boolean {
-        let maximized = this.meta.get_maximized() == Meta.MaximizeFlags.BOTH;
+        let maximized = this.meta.get_maximized() !== 0;
         return maximized;
     }
 

--- a/src/window.ts
+++ b/src/window.ts
@@ -532,7 +532,7 @@ export class ShellWindow {
                 if (stack) {
                     let stack_tab_height = stack.tabs_height;
 
-                    if (borderSize === 0 || this.grab === null) { // not in max screen state
+                    if (borderSize === 0 || this.grab) { // not in max screen state
                         stack_tab_height = 0;
                     }
 
@@ -559,12 +559,12 @@ export class ShellWindow {
 
                 if (workspace === null) return;
 
-                const screen = workspace.get_work_area_for_monitor(this.meta.get_monitor())
+                /*const screen = workspace.get_work_area_for_monitor(this.meta.get_monitor())
 
                 if (screen) {
                     width = Math.min(width, screen.x + screen.width)
                     height = Math.min(height, screen.y + screen.height)
-                }
+                }*/
 
                 border.set_position(x, y)
                 border.set_size(width, height)


### PR DESCRIPTION
Fixes #990 
Fixes #1013 
Implements #882 hide hint by checking monitor count if single on max state - there seems to be a consensus to still display hint on multi-monitor setup