### PR TITLE
fix preferences window crash in gnome 40

### DIFF
--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -70,7 +70,10 @@ function settings_dialog_view(): [AppWidgets, Gtk.Container] {
     let grid = new Gtk.Grid({
         column_spacing: 12,
         row_spacing: 12,
-        margin: 10
+        margin_start: 10,
+        margin_end: 10,
+        margin_bottom: 10,
+        margin_top: 10,
     });
 
     let win_label = new Gtk.Label({


### PR DESCRIPTION
Fixes the preferences window from crashing in Gnome 40.

Here are the stack details from the crash before the fix:

```
Error: No property margin on GtkGrid

Stack trace:
  _init/Gtk.Widget.prototype._init@resource:///org/gnome/gjs/modules/core/overrides/Gtk.js:45:40
  settings_dialog_view@/home/michael/.local/share/gnome-shell/extensions/pop-shell@system76.com/prefs.js:46:16
  settings_dialog_new@/home/michael/.local/share/gnome-shell/extensions/pop-shell@system76.com/prefs.js:9:23
  buildPrefsWidget@/home/michael/.local/share/gnome-shell/extensions/pop-shell@system76.com/prefs.js:127:18
  _init@resource:///org/gnome/Shell/Extensions/js/extensionsService.js:209:40
  OpenExtensionPrefsAsync/<@resource:///org/gnome/Shell/Extensions/js/extensionsService.js:122:28
  asyncCallback@resource:///org/gnome/gjs/modules/core/overrides/Gio.js:115:22
  run@resource:///org/gnome/Shell/Extensions/js/dbusService.js:177:20
  main@resource:///org/gnome/Shell/Extensions/js/main.js:19:13
  run@resource:///org/gnome/gjs/modules/script/package.js:206:19
  start@resource:///org/gnome/gjs/modules/script/package.js:190:8
  @/usr/share/gnome-shell/org.gnome.Shell.Extensions:1:17
```

This change is required because preferences in gnome 40 are required to use gtk 4.

I applied a similar fix to my extension: https://github.com/MichaelAquilina/improved-workspace-indicator/commit/0989b692fd801412f3ec3492cc69467bd0754eea which worked was approved by the gnome review team