### PR TITLE
fix(launcher): change icon from application-default to new-window

### DIFF
--- a/src/dialog_launcher.ts
+++ b/src/dialog_launcher.ts
@@ -109,7 +109,7 @@ export class Launcher extends search.Search {
                         const button = new launch.SearchOption(
                             name,
                             generic ? generic + " — " + where : where,
-                            'application-default-symbolic',
+                            'new-window-symbolic',
                             { gicon: app.icon() },
                             this.icon_size(),
                             { app },


### PR DESCRIPTION
Changes the icon for the "Launch new window" icon from `application-default` to `new-window`.

![Screenshot from 2021-06-24 10-12-02](https://user-images.githubusercontent.com/5883565/123297568-e8dec180-d4d4-11eb-8817-1f585c172942.png)
