### PR TITLE
fix (launcher): avoid one-character searches

### DIFF
--- a/src/dialog_launcher.ts
+++ b/src/dialog_launcher.ts
@@ -79,7 +79,7 @@ export class Launcher extends search.Search {
 
             const navigating_files = pat.startsWith("/") || pat.startsWith("~")
 
-            if (pat !== '?' && ! navigating_files) {
+            if (pat !== '?' && ! navigating_files && pat.length > 1) {
                 const needles = pattern.split(' ');
 
                 const contains_pattern = (haystack: string, needles: Array<string>): boolean => {


### PR DESCRIPTION
Massively speeds up launcher performance.

Fixes #1053.