### PR TITLE
adding a keyword to the logout script

### DIFF
--- a/src/scripts/session-logout.sh
+++ b/src/scripts/session-logout.sh
@@ -3,6 +3,6 @@
 # name: Log Out
 # icon: system-log-out
 # description: Log out to the login screen
-# keywords: log out
+# keywords: log out logout
 
 gnome-session-quit --logout


### PR DESCRIPTION
having `log` and `out` in the keywords section is great but if you type the full word logout this script does not show up. I think it should. I *think* this change will fix that.