### PR TITLE
Fix handling skip taskbar on LTS and latest

### DIFF
--- a/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
@@ -22,6 +22,11 @@
             <summary>Show title bars on windows with server-side decorations</summary>
         </key>
 
+        <key type="b" name="show-skip-taskbar">
+            <default>false</default>
+            <summary>Handle skip taskbar windows or windows with minimized to tray option</summary>
+        </key>
+
         <!-- Tiling Options -->
         <key type="u" name="column-size">
             <default>64</default>

--- a/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
@@ -23,8 +23,8 @@
         </key>
 
         <key type="b" name="show-skip-taskbar">
-            <default>false</default>
-            <summary>Handle skip taskbar windows or windows with minimized to tray option</summary>
+            <default>true</default>
+            <summary>Handle minimized to tray windows</summary>
         </key>
 
         <!-- Tiling Options -->

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,6 +47,7 @@ const { layoutManager, loadTheme, overview, panel, setThemeStylesheet, screenShi
 const { ScreenShield } = imports.ui.screenShield;
 const { AppSwitcher, AppIcon, WindowSwitcherPopup } = imports.ui.altTab;
 const { SwitcherList } = imports.ui.switcherPopup;
+const { WindowPreview } = imports.ui.windowPreview;
 const { Workspace } = imports.ui.workspace;
 const { WorkspaceThumbnail } = imports.ui.workspaceThumbnail;
 const Tags = Me.imports.tags;
@@ -1745,6 +1746,13 @@ export class Ext extends Ecs.System<ExtEvent> {
                 case 'smart-gaps':
                     this.on_smart_gap();
                     this.show_border_on_focused();
+                    break;
+                case 'show-skip-taskbar':
+                    if (this.settings.show_skiptaskbar()) {
+                        _show_skip_taskbar_windows();
+                    } else {
+                        _hide_skip_taskbar_windows();
+                    }
             }
         });
 
@@ -2404,10 +2412,6 @@ export class Ext extends Ecs.System<ExtEvent> {
 
 let ext: Ext | null = null;
 let indicator: Indicator | null = null;
-let default_isoverviewwindow_ws: any;
-let default_isoverviewwindow_ws_thumbnail: any;
-let default_init_appswitcher: any;
-let default_getwindowlist_windowswitcher: any;
 
 // @ts-ignore
 function init() {
@@ -2417,8 +2421,6 @@ function init() {
 // @ts-ignore
 function enable() {
     log.info("enable");
-
-    _show_skip_taskbar_windows();
 
     if (!ext) {
         ext = new Ext();
@@ -2454,8 +2456,6 @@ function enable() {
 // @ts-ignore
 function disable() {
     log.info("disable");
-
-    _hide_skip_taskbar_windows();
 
     if (ext) {
         if (sessionMode.isLocked) {
@@ -2536,19 +2536,38 @@ function* iter_workspaces(manager: any): IterableIterator<[number, any]> {
     }
 }
 
+let default_isoverviewwindow_ws: any;
+let default_isoverviewwindow_ws_thumbnail: any;
+let default_init_appswitcher: any;
+let default_getwindowlist_windowswitcher: any;
+let default_getcaption_windowpreview: any;
+
 /**
  * Decorates the default gnome-shell workspace/overview handling 
  * of skip_task_bar. And have those window types included in pop-shell.
  * Should only be called on extension#enable()
  */
 function _show_skip_taskbar_windows() {
-    // Handle the overview
-    default_isoverviewwindow_ws = Workspace.prototype._isOverviewWindow;
-    Workspace.prototype._isOverviewWindow = function(window: any) {
-        // wm_class Gjs needs to be skipped to prevent the ghost window in
-        // workspace and overview
-        return (window.skip_taskbar && window.get_wm_class() !== "Gjs") || 
-            default_isoverviewwindow_ws(window);
+    if (!GNOME_VERSION?.startsWith("40.")) {
+        // Handle the overview
+        default_isoverviewwindow_ws = Workspace.prototype._isOverviewWindow;
+        Workspace.prototype._isOverviewWindow = function(window: any) {
+            // wm_class Gjs needs to be skipped to prevent the ghost window in
+            // workspace and overview
+            return (window.skip_taskbar && window.get_wm_class() !== "Gjs") || 
+                default_isoverviewwindow_ws(window);
+        };
+    }
+
+    // Handle _getCaption errors
+    default_getcaption_windowpreview = WindowPreview.prototype._getCaption;
+    WindowPreview.prototype._getCaption = function() {
+        if (this.metaWindow.title)
+            return this.metaWindow.title;
+
+        let tracker = Shell.WindowTracker.get_default();
+        let app = tracker.get_window_app(this.metaWindow);
+        return app? app.get_name() : "";
     };
 
     // Handle the workspace thumbnail
@@ -2634,7 +2653,10 @@ function _show_skip_taskbar_windows() {
  * Should only be called on extension#disable()
  */
 function _hide_skip_taskbar_windows() {
-    Workspace.prototype._isOverviewWindow = default_isoverviewwindow_ws;
+    if (!GNOME_VERSION?.startsWith("40.")) {
+        Workspace.prototype._isOverviewWindow = default_isoverviewwindow_ws;
+    }
+    WindowPreview.prototype._getCaption = default_getcaption_windowpreview;
     WorkspaceThumbnail.prototype._isOverviewWindow = 
         default_isoverviewwindow_ws_thumbnail;
     AppSwitcher.prototype._init = default_init_appswitcher;

--- a/src/plugin_shell.ts
+++ b/src/plugin_shell.ts
@@ -31,9 +31,13 @@ const SELECTIONS: Array<Selection> = [
     {
         id: 4,
         name: "Toggle Window Tiling",
-        description: "Tiled windows are arranged side by side on the screen"
-    }
-    
+        description: "Tiled windows are arranged side by side on the screen",
+    },
+    {
+        id: 5,
+        name: "Toggle Minimized to Tray Windows (Experimental)",
+        description: "Handle windows with minimized to tray or skip taskbar option",
+    },
 ]
 
 export class ShellBuiltin extends plugins.Builtin {
@@ -63,6 +67,9 @@ export class ShellBuiltin extends plugins.Builtin {
                 break
             case 4:
                 ext.toggle_tiling()
+                break
+            case 5:
+                ext.settings.set_show_skiptaskbar(!ext.settings.show_skiptaskbar());
                 break
         }
 

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -100,7 +100,7 @@ function settings_dialog_view(): [AppWidgets, Gtk.Container] {
     });
 
     let show_skip_taskbar_label = new Gtk.Label({
-        label: "Show Skip Taskbar",
+        label: "Show Minimize to Tray Windows",
         xalign: 0.0
     });
     

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -17,6 +17,7 @@ interface AppWidgets {
     smart_gaps: any,
     snap_to_grid: any,
     window_titles: any,
+    show_skip_taskbar: any,
 }
 
 // @ts-ignore
@@ -63,6 +64,12 @@ function settings_dialog_new(): Gtk.Container {
         }
     });
 
+    app.show_skip_taskbar.set_active(ext.show_skiptaskbar());
+    app.show_skip_taskbar.connect('state-set', (_widget: any, state: boolean) => {
+        ext.set_show_skiptaskbar(state);
+        Settings.sync();
+    });
+
     return grid;
 }
 
@@ -92,11 +99,15 @@ function settings_dialog_view(): [AppWidgets, Gtk.Container] {
         xalign: 0.0
     });
 
+    let show_skip_taskbar_label = new Gtk.Label({
+        label: "Show Skip Taskbar",
+        xalign: 0.0
+    });
+    
     let window_titles = new Gtk.Switch({ halign: Gtk.Align.END });
-
     let snap_to_grid = new Gtk.Switch({ halign: Gtk.Align.END });
-
     let smart_gaps = new Gtk.Switch({ halign: Gtk.Align.END });
+    let show_skip_taskbar = new Gtk.Switch({ halign: Gtk.Align.END });
 
     grid.attach(win_label, 0, 0, 1, 1);
     grid.attach(window_titles, 1, 0, 1, 1);
@@ -107,11 +118,14 @@ function settings_dialog_view(): [AppWidgets, Gtk.Container] {
     grid.attach(smart_label, 0, 2, 1, 1);
     grid.attach(smart_gaps, 1, 2, 1, 1);
 
-    logging_combo(grid, 3);
+    grid.attach(show_skip_taskbar_label, 0, 3, 1, 1);
+    grid.attach(show_skip_taskbar, 1, 3, 1, 1);
 
-    let [inner_gap, outer_gap] = gaps_section(grid, 4);
+    logging_combo(grid, 4);
 
-    let settings = { inner_gap, outer_gap, smart_gaps, snap_to_grid, window_titles };
+    let [inner_gap, outer_gap] = gaps_section(grid, 5);
+
+    let settings = { inner_gap, outer_gap, smart_gaps, snap_to_grid, window_titles, show_skip_taskbar };
 
     return [settings, grid];
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -59,6 +59,7 @@ const TILE_BY_DEFAULT = "tile-by-default";
 const HINT_COLOR_RGBA = "hint-color-rgba";
 const DEFAULT_RGBA_COLOR = "rgba(251, 184, 108, 1)"; //pop-orange
 const LOG_LEVEL = "log-level";
+const SHOW_SKIPTASKBAR = "show-skip-taskbar";
 
 export class ExtensionSettings {
     ext: Settings = settings_new_schema(extension.metadata["settings-schema"]);
@@ -146,6 +147,10 @@ export class ExtensionSettings {
         return this.ext.get_uint(LOG_LEVEL);
     }
 
+    show_skiptaskbar(): boolean {
+        return this.ext.get_boolean(SHOW_SKIPTASKBAR);
+    }
+
     // Setters
 
     set_active_hint(set: boolean) {
@@ -196,5 +201,9 @@ export class ExtensionSettings {
 
     set_log_level(set: number) {
         this.ext.set_uint(LOG_LEVEL, set);
+    }
+
+    set_show_skiptaskbar(set: boolean) {
+        this.ext.set_boolean(SHOW_SKIPTASKBAR, set);
     }
 }


### PR DESCRIPTION
Fixes #1051 (when skip taskbar on/off)
Fixes #1055 (skip taskbar off)
Fixes #1058 (skip taskbar on/off)
Fixes #1066 - 20.04 LTS 3.36 (skip taskbar on/off)
#1023 is not on the switch.
Fixes #1034 - added Guake and ddterm to default floats

Need to test against ddterm or guake (skip taskbar but need to be floating by default - which I think need to be added to config.ts). These in addition to Sleek (minimize to tray only which is one of those types of windows that are being supported by this feature).

The skip taskbar feature is also on a switch. And by default on now in prefs.js

Hopefully this is better than the last PR.