### PR TITLE
Add Plank to skip taskbar exceptions

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -61,6 +61,7 @@ export const SKIPTASKBAR_EXCEPTIONS: Array<WindowRule> = [
     { class: "Conky", },
     { class: "Guake", },
     { class: "Com.github.amezin.ddterm", },
+    { class: "plank", },
 ];
 
 export interface FloatRule {


### PR DESCRIPTION
Fixes #1095.

(Plank has two WM_CLASS values, `plank` and `Plank`; I used the first one.)