### PR TITLE
adds Emojipedia and Giphy search

### DIFF
--- a/src/plugins/web/main.js
+++ b/src/plugins/web/main.js
@@ -28,7 +28,9 @@ const ENTRIES = new Map([
     ['twitch', { query: 'https://www.twitch.tv/search?term=', name: 'Twitch' }],
     ['yh', { query: 'https://search.yahoo.com/search?p=', name: 'Yahoo!' }],
     ['alie', { query: 'https://www.aliexpress.com/wholesale?SearchText=', name: 'AliExpress' }],
-    ['dev', { query: 'https://dev.to/search?q=', name: 'DEV Community' }]
+    ['dev', { query: 'https://dev.to/search?q=', name: 'DEV Community' }],
+    ['emoji', { query: 'https://emojipedia.org/search/?q=', name: 'Emojipedia' }],
+    ['giphy', { query: 'https://giphy.com/search/', name: 'Giphy' }]
 ])
 
 class App {

--- a/src/plugins/web/meta.json
+++ b/src/plugins/web/meta.json
@@ -1,7 +1,7 @@
 {
     "name": "Web Search",
     "description": "Site-specific web search",
-    "pattern": "^(amazon|wiki|bing|ddg|google|yt|stack|crates|arch|pp|ppw|rdt|bc|lib|npm|gist|fh|gh|dev|sdcl|twitch|yh|alie)\\s.*",
+    "pattern": "^(amazon|wiki|bing|ddg|google|yt|stack|crates|arch|pp|ppw|rdt|bc|lib|npm|gist|fh|gh|dev|sdcl|twitch|yh|alie|emoji|giphy)\\s.*",
     "exec": "main.js",
     "icon": "system-search",
     "fill": "ddg ",


### PR DESCRIPTION
This PR adds support for Emojipedia and Giphy search for the Pop Launcher. It has been built and tested on Pop 21.04 with the latest pop-shell build: 1.1.0~1626357201~21.04~c1f2ea4
