### PR TITLE
fix: Focus handling improvements to fix inconsistencies in window add / remove

### DIFF
--- a/src/auto_tiler.ts
+++ b/src/auto_tiler.ts
@@ -655,11 +655,13 @@ export class AutoTiler {
             return Err('ignoring focus');
         }
 
-        if (!ext.prev_focused) {
+        const prev = ext.prev_focused[0]
+
+        if (!prev) {
             return Err('no window has been previously focused');
         }
 
-        let onto = ext.windows.get(ext.prev_focused);
+        let onto = ext.windows.get(prev);
 
         if (!onto) {
             return Err('no focus window');


### PR DESCRIPTION
Sometimes when a new window is opened, the window is placed in a prior-focused stack or window, rather than the actively-focused stack or window. Additionally, when a window in a stack is destroyed, sometimes the focus shifts to a completely different window or stack. These changes should fix the focus handling to correctly append to the actively-focused window, and activate a sibling in the actively-focused stack.