### PR TITLE
fix(tiling): support resizing/moving windows with the mouse in GNOME 40

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1790,7 +1790,6 @@ export class Ext extends Ecs.System<ExtEvent> {
         });
 
         if (GNOME_VERSION?.startsWith("3.")) {
-            // GNOME 40 removed the first argument of the callback
             this.connect(display, 'grab-op-begin', (_, _display, win, op) => {
                 this.on_grab_start(win, op);
             });
@@ -1799,6 +1798,7 @@ export class Ext extends Ecs.System<ExtEvent> {
                 this.register_fn(() => this.on_grab_end(win, op));
             });
         } else {
+            // GNOME 40 removed the first argument of the callback
             this.connect(display, 'grab-op-begin', (_display, win, op) => {
                 this.on_grab_start(win, op);
             });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1789,14 +1789,24 @@ export class Ext extends Ecs.System<ExtEvent> {
             this.register({ tag: 3, window });
         });
 
-        this.connect(display, 'grab-op-begin', (_, _display, win, op) => {
-            this.on_grab_start(win, op);
-        });
+        if (GNOME_VERSION?.startsWith("3.")) {
+            // GNOME 40 removed the first argument of the callback
+            this.connect(display, 'grab-op-begin', (_, _display, win, op) => {
+                this.on_grab_start(win, op);
+            });
 
-        this.connect(display, 'grab-op-end', (_, _display, win, op) => {
-            this.register_fn(() => this.on_grab_end(win, op));
+            this.connect(display, 'grab-op-end', (_, _display, win, op) => {
+                this.register_fn(() => this.on_grab_end(win, op));
+            });
+        } else {
+            this.connect(display, 'grab-op-begin', (_display, win, op) => {
+                this.on_grab_start(win, op);
+            });
 
-        });
+            this.connect(display, 'grab-op-end', (_display, win, op) => {
+                this.register_fn(() => this.on_grab_end(win, op));
+            });
+        }
 
         this.connect(overview, 'window-drag-begin', (_, win) => {
             this.on_grab_start(win, 1)


### PR DESCRIPTION
Fixes #932.