### PR TITLE
improv: Use `imports.misc.config.PACKAGE_VERSION`

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,7 +53,7 @@ const Tags = Me.imports.tags;
 
 const STYLESHEET_PATHS = ['light', 'dark'].map(stylesheet_path);
 const STYLESHEETS = STYLESHEET_PATHS.map((path) => Gio.File.new_for_path(path));
-const GNOME_VERSION = utils.gnome_version()
+const GNOME_VERSION = imports.misc.config.PACKAGE_VERSION;
 
 enum Style { Light, Dark }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -137,13 +137,6 @@ export function async_process_ipc(argv: Array<string>): AsyncIPC | null {
     return { stdin, stdout }
 }
 
-export function gnome_version(): null | string {
-    let [,out] = GLib.spawn_command_line_sync("gnome-shell --version");
-    if (!out) return null;
-
-    return imports.byteArray.toString(out).split(' ')[2]
-}
-
 export function map_eq<K, V>(map1: Map<K, V>, map2: Map<K, V>) {
     if (map1.size !== map2.size) {
         return false


### PR DESCRIPTION
Since this exists, it seems better than spawning a subprocess.

This should have no impact on behavior (except theoretically being faster).