### PR TITLE
improv(calc): Use `BigNumber` representation

### DIFF
--- a/src/plugins/calc/main.js
+++ b/src/plugins/calc/main.js
@@ -8,7 +8,8 @@ const SCRIPT_DIR = GLib.path_get_dirname(new Error().stack.split(':')[0].slice(1
 /** Add our directory so we can import modules from it. */
 imports.searchPath.push(SCRIPT_DIR)
 
-const { evaluate } = imports.math.math;
+const math = imports.math.math;
+math.config({number: 'BigNumber'});
 
 /**
  * Request received by the Pop Shell launcher
@@ -44,7 +45,7 @@ class App {
         this.last_query = input.substr(1)
 
         try {
-            this.last_value = evaluate(this.last_query).toString()
+            this.last_value = math.evaluate(this.last_query).toString()
         } catch (e) {
             this.last_value = this.last_query + ` x = ?`
         }


### PR DESCRIPTION
Resolves https://github.com/pop-os/shell/issues/1120.

This should better match the behavior of calculators like gnome-calculator.

As far as I'm aware, the only downside of this is performance. Which probably isn't an issue when just using math.js as a calculator (vs trying to script loops of calculations).