### PR TITLE
Add Geometry Dash to skip taskbar exceptions

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -62,6 +62,7 @@ export const SKIPTASKBAR_EXCEPTIONS: Array<WindowRule> = [
     { class: "Guake", },
     { class: "Com.github.amezin.ddterm", },
     { class: "plank", },
+    { class: "geometrydash.exe", },
 ];
 
 export interface FloatRule {


### PR DESCRIPTION
Intended to close https://github.com/pop-os/shell/issues/1123; needs tested by someone who owns Geometry Dash.

Not sure if this is the best long-term solution to the issue. If the issue affects many full-screen games, then better handling may be needed down the line.