### PR TITLE
fix: toggle the window skip taskbar handling

### DIFF
--- a/src/window.ts
+++ b/src/window.ts
@@ -271,6 +271,7 @@ export class ShellWindow {
 
             // Only normal windows will be considered for tiling
             return this.meta.window_type == Meta.WindowType.NORMAL
+                && (this.meta.is_skip_taskbar() && ext.settings.show_skiptaskbar())
                 // Transient windows are most likely dialogs
                 && !this.is_transient()
                 // If a window lacks a class, it's probably a web browser dialog


### PR DESCRIPTION
Tiling of skip taskbar windows is always on. Put that logic on the toggle as well.
This conditionally fixes #1104 - user has to turn it off (`Show Minimize to Tray Windows`) since it is turned on by default