### PR TITLE
Listening for WM_CLASS change

### DIFF
--- a/src/window.ts
+++ b/src/window.ts
@@ -587,7 +587,7 @@ export class ShellWindow {
     }
 
     private wm_class_changed() {
-        if (this.is_tilable(this.ext) && !this.meta.minimized) {
+        if (this.is_tilable(this.ext)) {
             this.ext.connect_window(this);
             if (!this.meta.minimized) {
                 this.ext.auto_tiler?.auto_tile(this.ext, this, this.ext.init);

--- a/src/window.ts
+++ b/src/window.ts
@@ -126,6 +126,7 @@ export class ShellWindow {
                 this.meta.connect('size-changed', () => { this.window_changed() }),
                 this.meta.connect('position-changed', () => { this.window_changed() }),
                 this.meta.connect('workspace-changed', () => { this.workspace_changed() }),
+                this.meta.connect('notify::wm-class', () => { this.wm_class_changed(); }),
                 this.meta.connect('raised', () => { this.window_raised() }),
             );
     }
@@ -524,7 +525,7 @@ export class ShellWindow {
     }
 
     update_border_layout() {
-        let {x, y, width, height} = this.meta.get_frame_rect();
+        let { x, y, width, height } = this.meta.get_frame_rect();
 
         const border = this.border;
         let borderSize = this.border_size;
@@ -581,6 +582,15 @@ export class ShellWindow {
 
                 border.set_position(x, y)
                 border.set_size(width, height)
+            }
+        }
+    }
+
+    private wm_class_changed() {
+        if (this.is_tilable(this.ext) && !this.meta.minimized) {
+            this.ext.connect_window(this);
+            if (!this.meta.minimized) {
+                this.ext.auto_tiler?.auto_tile(this.ext, this, this.ext.init);
             }
         }
     }


### PR DESCRIPTION
When windows are created, they will now listen for updates to their
wm_class. This commit is motivated because some apps (notibly spotify)
don't set their wm_class property before creating the main window.

This patch allows pop-shell to work with spotify (and similar
applications) by tiling the window once it receives a valid wm_class.

This fixes #740.