### PR TITLE
fix: Disable config file monitoring due to GJS thread lock

### DIFF
--- a/src/dialog_add_exception.ts
+++ b/src/dialog_add_exception.ts
@@ -15,7 +15,7 @@ export class AddExceptionDialog {
         shouldFadeOut: false
     });
 
-    constructor(cancel: () => void, this_app: () => void, current_window: () => void) {
+    constructor(cancel: () => void, this_app: () => void, current_window: () => void, on_close: () => void) {
         let title = St.Label.new("Add Floating Window Exception");
         title.set_x_align(Clutter.ActorAlign.CENTER)
         title.set_style("font-weight: bold")
@@ -34,6 +34,7 @@ export class AddExceptionDialog {
             label: "Cancel",
             action: () => {
                 cancel();
+                on_close()
                 this.close();
             },
             key: Clutter.KEY_Escape
@@ -43,6 +44,7 @@ export class AddExceptionDialog {
             label: "This App's Windows",
             action: () => {
                 this_app();
+                on_close()
                 this.close();
             },
         });
@@ -51,6 +53,7 @@ export class AddExceptionDialog {
             label: "Current Window Only",
             action: () => {
                 current_window();
+                on_close()
                 this.close();
             }
         })

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -554,20 +554,11 @@ export class Ext extends Ecs.System<ExtEvent> {
     }
 
     exception_select() {
-        if (GNOME_VERSION?.startsWith("3.36")) {
-            // 3.36 required a delay to work
-            GLib.timeout_add(GLib.PRIORITY_LOW, 500, () => {
-                this.exception_selecting = true
-                overview.show()
-                return false
-            })
-        } else {
-            GLib.idle_add(GLib.PRIORITY_LOW, () => {
-                this.exception_selecting = true
-                overview.show()
-                return false
-            })
-        }
+        GLib.timeout_add(GLib.PRIORITY_LOW, 500, () => {
+            this.exception_selecting = true
+            overview.show()
+            return false
+        })
     }
 
     exit_modes() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -419,29 +419,30 @@ export class Ext extends Ecs.System<ExtEvent> {
         return window ? window.meta.get_compositor_private() : null;
     }
 
-    attach_config(): [any, SignalID] {
-        const monitor = this.conf_watch = Gio.File.new_for_path(Config.CONF_FILE)
-            .monitor(Gio.FileMonitorFlags.NONE, null);
+    // TODO: Causes gjs to burn CPU cycles in a lock
+    // attach_config(): [any, SignalID] {
+    //     const monitor = this.conf_watch = Gio.File.new_for_path(Config.CONF_FILE)
+    //         .monitor(Gio.FileMonitorFlags.NONE, null);
 
-        return [monitor, monitor.connect('changed', () => {
-            this.conf.reload()
+    //     return [monitor, monitor.connect('changed', () => {
+    //         this.conf.reload()
 
-            // If the auto-tilable status of a window has changed, detach or attach the window.
-            if (this.auto_tiler) {
-                const at = this.auto_tiler;
-                for (const [entity, window] of this.windows.iter()) {
-                    const attachment = at.attached.get(entity);
-                    if (window.is_tilable(this)) {
-                        if (!attachment) {
-                            at.auto_tile(this, window, this.init);
-                        }
-                    } else if (attachment) {
-                        at.detach_window(this, entity)
-                    }
-                }
-            }
-        })];
-    }
+    //         // If the auto-tilable status of a window has changed, detach or attach the window.
+    //         if (this.auto_tiler) {
+    //             const at = this.auto_tiler;
+    //             for (const [entity, window] of this.windows.iter()) {
+    //                 const attachment = at.attached.get(entity);
+    //                 if (window.is_tilable(this)) {
+    //                     if (!attachment) {
+    //                         at.auto_tile(this, window, this.init);
+    //                     }
+    //                 } else if (attachment) {
+    //                     at.detach_window(this, entity)
+    //                 }
+    //             }
+    //         }
+    //     })];
+    // }
 
     /// Connects a callback signal to a GObject, and records the signal.
     connect(object: GObject.Object, property: string, callback: (...args: any) => boolean | void): SignalID {
@@ -1703,7 +1704,7 @@ export class Ext extends Ecs.System<ExtEvent> {
 
     /** Begin listening for signals from windows, and add any pre-existing windows. */
     signals_attach() {
-        this.conf_watch = this.attach_config();
+        // this.conf_watch = this.attach_config();
 
         this.tiler.queue.start(100, (movement) => {
             movement()

--- a/src/floating_exceptions/src/main.ts
+++ b/src/floating_exceptions/src/main.ts
@@ -259,7 +259,7 @@ class App {
             switch (event.tag) {
                 // SelectWindow
                 case 0:
-                    println(`SELECT`)
+                    println("SELECT")
                     Gtk.main_quit()
                     break
 
@@ -282,12 +282,14 @@ class App {
                 case 2:
                     log(`toggling exception ${event.enable}`)
                     this.config.toggle_system_exception(event.wmclass, event.wmtitle, !event.enable)
+                    println("MODIFIED")
                     break
 
                 // RemoveException
                 case 3:
                     log(`removing exception`)
                     this.config.remove_user_exception(event.wmclass, event.wmtitle)
+                    println("MODIFIED")
                     break
 
             }


### PR DESCRIPTION
Experienced GJS burning CPU the moment that I removed the local config files. Listening to `changed` events on a `Gio.File` seems to trigger the behavior.

Fixes #969 