### PR TITLE
Add tilda to default float-rules

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -38,6 +38,7 @@ export const DEFAULT_FLOAT_RULES: Array<FloatRule> = [
     { class: "KotatogramDesktop", title: "Media viewer" },
     { class: "Steam", title: "^((?!Steam).)*$" },
     { class: "TelegramDesktop", title: "Media viewer" },
+    { class: "tilda", },
     { class: "Solaar", },
     { class: "system76-driver", },
     { class: "zoom", },


### PR DESCRIPTION
Tilda is a dropdown terminal, similar to guake which is already on this list.
The 'select window' interface of popshell didn't work for this app (it doesn't appear on the window overview) so adding it by default could save some people some time.