### PR TITLE
Fixes 967...?

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -274,7 +274,6 @@ export class Ext extends Ecs.System<ExtEvent> {
         switch (event.tag) {
             /** Callback Event */
             case 1:
-                (event.callback)();
                 break
 
             /** Window Event */


### PR DESCRIPTION
Fixes #967.

**Please review and test thoroughly, because I do not fully understand why this fix works**, and simply bisected the entire code base to find that the crash does not happen without this line. I performed some basic, interactive tests to verify the behavior of launcher is otherwise correct, but I cannot be sure that not calling some callbacks would have no other effects. In fact, it is probably a very bad idea to _not_ run a callback.

I was unable to capture what callback was responsible for the crash, because print statements attempting to dump callback yielded nothing when crash happened. 

I need someone more familiar with the code base to guide me through why this is happening. I especially need to understand where these events are generated, and how the ECS architecture works.