### PR TITLE
fix(launcher): Empty window list with Spotify Flatpak

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -249,8 +249,8 @@ export class Ext extends Ecs.System<ExtEvent> {
             for (const window of this.tab_list(Meta.TabList.NORMAL, null)) {
                 wins.push([
                     window.entity,
-                    window.meta.get_title(),
-                    window.name(this),
+                    window.title(),
+                    window.name(this)
                 ])
             }
 
@@ -500,7 +500,7 @@ export class Ext extends Ecs.System<ExtEvent> {
                 let wmclass = win.meta.get_wm_class();
                 if (wmclass) this.conf.add_window_exception(
                     wmclass,
-                    win.meta.get_title()
+                    win.title()
                 );
                 this.exception_dialog()
             },

--- a/src/mod.d.ts
+++ b/src/mod.d.ts
@@ -195,7 +195,7 @@ declare namespace Meta {
         get_pid(): number;
         get_role(): null | string;
         get_stable_sequence(): number;
-        get_title(): string;
+        get_title(): null | string;
         get_transient_for(): Window | null;
         get_user_time(): number;
         get_wm_class(): string | null;

--- a/src/stack.ts
+++ b/src/stack.ts
@@ -92,7 +92,7 @@ export class Stack {
         if (!this.widgets) return;
 
         const entity = window.entity;
-        const label = window.meta.get_title();
+        const label = window.title()
         const active = Ecs.entity_eq(entity, this.active);
 
         const button: St.Button = new St.Button({
@@ -421,7 +421,7 @@ export class Stack {
             }
 
             this.watch_signals(this.active_id, c.button, window);
-            this.buttons.get(c.button)?.set_label(window.meta.get_title());
+            this.buttons.get(c.button)?.set_label(window.title());
             this.activate(window.entity);
         }
     }
@@ -576,7 +576,7 @@ export class Stack {
         this.tabs[comp].signals = [
             window.meta.connect('notify::title', () => {
                 this.window_exec(comp, entity, (window) => {
-                    this.buttons.get(button)?.set_label(window.meta.get_title())
+                    this.buttons.get(button)?.set_label(window.title())
                 });
             }),
 

--- a/src/window.ts
+++ b/src/window.ts
@@ -298,7 +298,7 @@ export class ShellWindow {
                 // If a window lacks a class, it's probably a web browser dialog
                 && wm_class !== null
                 // Blacklist any windows that happen to leak through our filter
-                && !ext.conf.window_shall_float(wm_class, this.meta.get_title());
+                && !ext.conf.window_shall_float(wm_class, this.title());
         };
 
         return !ext.contains_tag(this.entity, Tags.Floating)
@@ -400,6 +400,11 @@ export class ShellWindow {
 
         other.move(ext, ar);
         this.move(ext, br, () => place_pointer_on(this.ext.conf.default_pointer_position, this.meta));
+    }
+
+    title(): string {
+        const title = this.meta.get_title();
+        return title ? title : this.name(this.ext)
     }
 
 


### PR DESCRIPTION
Spotify Flatpak returns `null` for `meta.get_title()`. Use window name instead.

Closes #1208 