### PR TITLE
fix(exception): Add ibus dialogs for Wayland

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -48,7 +48,8 @@ export const DEFAULT_FLOAT_RULES: Array<FloatRule> = [
     { class: "Gnome-initial-setup" },
     { class: "Steam", title: "^.*(Guard|Login).*" },
     { class: "krunner" },
-    { class: "ibus-.*" }
+    { class: "ibus-.*" },
+    { class: "gjs" }
 ];
 
 export interface WindowRule {


### PR DESCRIPTION
In Wayland sessions, the ibus dialog gets tiled when it shouldn't. This dialog can be triggered using the emoji input shortcut (Ctrl + Shift + E, followed by space).