### PR TITLE
Fix: Gnome 41 compatibility, update metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,7 @@
     "settings-schema": "org.gnome.shell.extensions.pop-shell",
     "shell-version": [
         "3.36",
-        "40.beta",
-        "41.beta"
+        "40",
+        "41"
     ]
 }


### PR DESCRIPTION
This was the only addition I had to make to get the extension to run on Gnome 41 (Fedora 35.) I didn't run into many issues during my testing, aside from the launcher not working which is unrelated since it's now separate - that was news to me as I was using the release version prior to this.

- [ ] Plug an additional display into a laptop - windows and workspaces don't changes

Gnome remembers the window layout to some degree, but it's far from perfect.

- [ ] Disabling window titles using global (Pop Shell) option works for Shell Shortcuts, LibreOffice, etc.

Tested on Wayland, titles can't be disabled.

--

I had some trouble on X, the tiling didn't work at all but was enabled. I don't use X at all, so it might be better for somebody else to properly test there.

## With tiling enabled

### Tiling

- [x] Super direction keys changes focus in the correct direction
- [x] Windows moved with the keyboard tile into place
- [x] Windows moved with the mouse tile into place
- [x] Windows swap with the keyboard (test with different size windows)
- [x] Windows can be resized with the keyboard (Test resizing four windows above, below, right, and left to ensure shortcut consistency)
- [x] Windows can be resized with the mouse
- [x] Minimizing a window detaches it from the tree and re-tiles remaining windows
- [x] Unminimizing a window re-tiles the window
- [x] Maximizing with the keyboard (`Super` `M`) covers tiled windows
- [x] Unmaximizing with keyboard (`Super` `M`) re-tiles into place
- [x] Maximizing with the mouse covers tiled windows
- [x] Unmaximizing with mouse re-tiles into place
- [x] Full-screening removes the active hint and full-screens on one display 
- [x] Unfull-screening adds the active hint and re-tiles into place
- [x] Maximizing a YouTube video fills the screen and unmaximizing retiles the browser in place
- [x] VIM shortcuts work as direction keys
- [x] `Super` `O` changes window orientation
- [x] `Super` `G` floats and then re-tiles a window
- [x] Float a window with `Super` `G`. It should be movable and resizeable in window management mode with keyboard keys
- [x] `Super` `Q` Closes a window
- [x] Turn off auto-tiling. New windows launch floating.
- [x] Turn on auto-tiling. Windows automatically tile.
- [x] Disabling and enabling auto-tiling correctly handles minimized, maximized, fullscreen, floating, and non-floating windows (This test needs a better definition, steps, or to be separated out.)

### Stacking

- [x] Windows can be moved into a stack.
- [x] Windows can be moved out of a stack.
- [x] Windows inside and outside of a stack can be swapped multiple times and in both directions.
- [x] Moving the last window out of a stack works as expected.
- [x] Stacks can be resized with the keyboard.
- [x] Stacks can be resized with the mouse.
- [x] Lock and unlock the screen-- stacks should still exist and windows should not have moved.
- [x] Full-screen an application within the stack, then quit the application-- the remaining tabs should be visible.

### Workspaces

- [x] Windows can be moved to another workspace with the keyboard
- [x] Windows can be moved to another workspace with the mouse
- [x] Windows can be moved to workspaces between existing workspaces
- [x] Moving windows to another workspace re-tiled the previous and new workspace
- [x] Active hint is present on the new workspace and once the window is returned to its previous workspace
- [x] Floating windows move across workspaces
- [x] Remove windows from the 2nd worspace in a 3 workspace setup. The 3rd workspace becomes the 2nd workspace, and tiling is unaffected by the move.

### Displays

- [x] Windows move across displays in adjustment mode with direction keys
- [x] Windows move across displays with the mouse
- [x] Changing the primary display moves the top bar. Window heights adjust on all monitors for the new position.
- [x] Unplug a display - windows from the display retile on a new workspace on the remaining display
- [ ] Plug an additional display into a laptop - windows and workspaces don't changes
- [ ] NOTE: Add vertical monitor layout test

### Launcher

- [ ] All windows on all workspaces appear on launch
- [ ] Choosing an app on another workspace moves workspaces and focus to that app
- [ ] Launching an application works
- [ ] Typing text and then removing it will re-show those windows
- [ ] Search works for applications and windows
- [ ] Search works for GNOME settings panels
- [ ] Search for "Extensions". There should be only one entry.
- [ ] The overlay hint correctly highlights the selected window
- [ ] Open windows are sorted above applications (e.g. "web browser")
- [ ] t: executes a command in a terminal
- [ ] : executes a command in sh
- [ ] = calculates an equation
- [ ] Search results are as expected:
    - `cal` returns Calendar and Calculator before Color
    - `pops` returns Popsicle first
    - `shop` returns the Pop!_Shop first

### Window Titles

- [ ] Disabling window titles using global (Pop Shell) option works for Shell Shortcuts, LibreOffice, etc.
- [x] Disabling window titles in Firefox works (Check debian and flatpak packages)

### Floating Exceptions

- [x] Add a window to floating exceptions-- it should float immediately.
- [x] Close and re-open the window-- it should float when opened.
- [x] Add an app to floating exceptions-- it should float immediately.
- [x] Close and re-open the app-- it should float when opened.

## With Tiling Disabled

### Tiling

- [x] Super direction keys changes focus in the correct direction
- [x] Windows can be moved with the keyboard
- [x] Windows can be moved with the mouse
- [x] Windows swap with the keyboard (test with different size windows)
- [x] Windows can be resized with the keyboard
- [x] Windows can be resized with the mouse
- [x] Windows can be half-tiled left and right with `Ctrl``Super``left`/`right`

### Displays

- [x] Windows move across displays in adjustment mode with directions keys
- [x] Windows move across displays with the mouse

### Miscellaneous

- [x] Close all windows-- no icons should be active in the GNOME launcher.
- [x] Open a window, enable tiling, stack the window, move to a different workspace, and disable tiling. The window should not become visible on the empty workspace.
- [x] Maximize a window, then open another app with the Activities overview. The newly-opened app should be visible and focused.
- [ ] Maximize a window, then open another app with the launcher. The newly-opened app should be visible and focused.
