### PR TITLE
fix: Give AppID of window to launcher

### DIFF
--- a/src/dbus_service.ts
+++ b/src/dbus_service.ts
@@ -14,7 +14,7 @@ const IFACE: string = `<node>
         <arg type="(uu)" direction="in" name="window"/>
     </method>
     <method name="WindowList">
-        <arg type="a((uu)ss)" direction="out" name="args"/>
+        <arg type="a((uu)sss)" direction="out" name="args"/>
     </method>
     <method name="WindowQuit">
         <arg type="(uu)" direction="in" name="window"/>
@@ -32,7 +32,7 @@ export class Service {
     FocusDown: () => void = () => {}
     Launcher: () => void = () => {}
     WindowFocus: (window: [number, number]) => void = () => {}
-    WindowList: () => Array<[[number, number], string, string]> = () => []
+    WindowList: () => Array<[[number, number], string, string, string]> = () => []
     WindowQuit: (window: [number, number]) => void = () => {}
 
     constructor() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -244,14 +244,16 @@ export class Ext extends Ecs.System<ExtEvent> {
             this.window_search.close()
         }
 
-        this.dbus.WindowList = (): Array<[[number, number], string, string]> => {
+        this.dbus.WindowList = (): Array<[[number, number], string, string, string]> => {
             const wins = new Array()
 
             for (const window of this.tab_list(Meta.TabList.NORMAL, null)) {
+                const string = window.window_app.get_id();
                 wins.push([
                     window.entity,
                     window.title(),
-                    window.name(this)
+                    window.name(this),
+                    string ? string : ""
                 ])
             }
 

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -119,7 +119,6 @@ export class Launcher extends search.Search {
                 if (item) {
                     try {
                         const button = new search.SearchOption(
-                            this.ext,
                             item.name,
                             item.description,
                             item.category_icon ? item.category_icon : null,
@@ -213,7 +212,7 @@ export class Launcher extends search.Search {
             log.error(`pop-launcher will use Gio.DesktopAppInfo instead`);
 
             const dapp = Gio.DesktopAppInfo.new_from_filename(entry.path);
-            
+
             if (!dapp) {
                 log.error(`could not find desktop entry for ${entry.path}`);
                 return;

--- a/src/search.ts
+++ b/src/search.ts
@@ -4,7 +4,6 @@ const Me = imports.misc.extensionUtils.getCurrentExtension();
 import * as Lib from 'lib';
 import * as rect from 'rectangle';
 
-import type { Ext } from 'extension'
 import type { JsonIPC } from 'launcher_service'
 
 const GLib: GLib = imports.gi.GLib;
@@ -138,7 +137,7 @@ export class Search {
             }
 
             this.last_trigger = global.get_current_time()
-            
+
             if (c === 65307) {
                 // Escape key was pressed
                 this.reset();
@@ -387,7 +386,7 @@ export class SearchOption {
 
     shortcut: St.Widget = new St.Label({ text: "", y_align: Clutter.ActorAlign.CENTER, style: "padding-left: 6px;padding-right: 6px" })
 
-    constructor(ext: Ext, title: string, description: null | string, category_icon: null | JsonIPC.IconSource, icon: null | JsonIPC.IconSource, icon_size: number,
+    constructor(title: string, description: null | string, category_icon: null | JsonIPC.IconSource, icon: null | JsonIPC.IconSource, icon_size: number,
                 exec: null | string, keywords: null | Array<string>) {
         this.title = title
         this.description = description
@@ -396,12 +395,12 @@ export class SearchOption {
 
         const layout = new St.BoxLayout({})
 
-        attach_icon(layout, category_icon, icon_size / 2, ext)
+        attach_icon(layout, category_icon, icon_size / 2)
 
         const label = new St.Label({ text: title })
         label.clutter_text.set_ellipsize(Pango.EllipsizeMode.END)
 
-        attach_icon(layout, icon, icon_size, ext)
+        attach_icon(layout, icon, icon_size)
 
         const info_box = new St.BoxLayout({ y_align: Clutter.ActorAlign.CENTER, vertical: true, x_expand: true });
         info_box.add_child(label)
@@ -418,9 +417,9 @@ export class SearchOption {
     }
 }
 
-function attach_icon(layout: any, icon: null | JsonIPC.IconSource, icon_size: number, ext: Ext) {
+function attach_icon(layout: any, icon: null | JsonIPC.IconSource, icon_size: number) {
     if (icon) {
-        const generated = generate_icon(icon, icon_size, ext)
+        const generated = generate_icon(icon, icon_size)
 
         if (generated) {
             generated.set_y_align(Clutter.ActorAlign.CENTER)
@@ -429,7 +428,7 @@ function attach_icon(layout: any, icon: null | JsonIPC.IconSource, icon_size: nu
     }
 }
 
-function generate_icon(icon: JsonIPC.IconSource, icon_size: number, ext: Ext): null | St.Widget {
+function generate_icon(icon: JsonIPC.IconSource, icon_size: number): null | St.Widget {
     let app_icon = null;
 
     if ("Name" in icon) {

--- a/src/search.ts
+++ b/src/search.ts
@@ -451,11 +451,6 @@ function generate_icon(icon: JsonIPC.IconSource, icon_size: number, ext: Ext): n
             gicon: Gio.content_type_get_icon(icon.Mime),
             icon_size,
         })
-    } else if ("Window" in icon) {
-        const window = ext.windows.get(icon.Window);
-        if (window) {
-            app_icon = window.icon(ext, icon_size);
-        }
     }
 
     if (app_icon) {

--- a/src/window.ts
+++ b/src/window.ts
@@ -67,9 +67,9 @@ export class ShellWindow {
 
     prev_rect: null | Rectangular = null;
 
-    private was_hidden: boolean = false;
+    window_app: any;
 
-    private window_app: any;
+    private was_hidden: boolean = false;
 
     private extra: X11Info = {
         normal_hints: new OnceCell(),


### PR DESCRIPTION
This will be useful in enabling a GTK launcher to know what icon to display.

Requires https://github.com/pop-os/launcher/pull/63