### PR TITLE
fix: allow floating exempt windows to be toggled

### DIFF
--- a/src/auto_tiler.ts
+++ b/src/auto_tiler.ts
@@ -498,10 +498,7 @@ export class AutoTiler {
             float_except = ext.conf.window_shall_float(wm_class, wm_title);
         }
 
-        if (ext.contains_tag(focused.entity, Tags.Floating) && !float_except) {
-            ext.delete_tag(focused.entity, Tags.Floating);
-            this.auto_tile(ext, focused, false);
-        } else if (!focused.is_tilable(ext)) {
+        if (float_except) {
             if (ext.contains_tag(focused.entity, Tags.ForceTile)) {
                 ext.delete_tag(focused.entity, Tags.ForceTile);
                 const fork_entity = this.attached.get(focused.entity);
@@ -509,18 +506,21 @@ export class AutoTiler {
                     this.detach_window(ext, focused.entity);
                 }
             } else {
-                if (!float_except) {
-                    ext.add_tag(focused.entity, Tags.ForceTile);
-                    this.auto_tile(ext, focused, false);
-                }
+                ext.add_tag(focused.entity, Tags.ForceTile);
+                this.auto_tile(ext, focused, false);
             }
-        } else {
-            const fork_entity = this.attached.get(focused.entity);
-            if (fork_entity) {
-                this.detach_window(ext, focused.entity);
-                ext.add_tag(focused.entity, Tags.Floating);
-            }
-        }
+	} else {
+	    if (ext.contains_tag(focused.entity, Tags.Floating)) {
+		ext.delete_tag(focused.entity, Tags.Floating);
+		this.auto_tile(ext, focused, false);
+	    } else {
+		const fork_entity = this.attached.get(focused.entity);
+		if (fork_entity) {
+		    this.detach_window(ext, focused.entity);
+		    ext.add_tag(focused.entity, Tags.Floating);
+		}
+	    }
+	}
     }
 
     toggle_orientation(ext: Ext, window: ShellWindow) {

--- a/src/window.ts
+++ b/src/window.ts
@@ -277,7 +277,7 @@ export class ShellWindow {
             }
 
             const role = this.meta.get_role();
-            
+
             // Quake-style terminals such as Tilix's quake mode.
             if (role === "quake") return false;
 
@@ -291,14 +291,18 @@ export class ShellWindow {
                 if (is_dialog || is_first_login) return false;
             }
 
+            // Blacklist any windows that happen to leak through our filter
+            // Windows that are tagged ForceTile are considered tilable despite exemption
+            if (wm_class !== null && ext.conf.window_shall_float(wm_class, this.title())) {
+                return ext.contains_tag(this.entity, Tags.ForceTile);
+            }
+
             // Only normal windows will be considered for tiling
             return this.meta.window_type == Meta.WindowType.NORMAL
                 // Transient windows are most likely dialogs
                 && !this.is_transient()
                 // If a window lacks a class, it's probably a web browser dialog
-                && wm_class !== null
-                // Blacklist any windows that happen to leak through our filter
-                && !ext.conf.window_shall_float(wm_class, this.title());
+                && wm_class !== null;
         };
 
         return !ext.contains_tag(this.entity, Tags.Floating)


### PR DESCRIPTION
This allows floating exempt windows to be toggled into tiling mode with
Super + G.  To ensure exempt windows are treated normally for movement
and placement, we must consider windows tagged with ForceTile to be
"is_tilable".

We handle these floating exempt windows separately from other windows in
toggle_floating by checking if they are exempt and then adding the
ForceTile tag to toggle floating on and then removing it when we toggle
it off.

Fixes #1222.