### PR TITLE
fix: crash overview on 4x when min tray enabled and remove dupe app icons on switch-app

### DIFF
--- a/src/mod.d.ts
+++ b/src/mod.d.ts
@@ -208,6 +208,7 @@ declare namespace Meta {
         is_client_decorated(): boolean;
         is_fullscreen(): boolean;
         is_on_all_workspaces(): boolean;
+        is_override_redirect(): boolean;
         is_skip_taskbar(): boolean;
         make_above(): void;
         make_fullscreen(): void;


### PR DESCRIPTION
Hopefully fixes #1251 for gnome 4x users. This should enable 4x to see the overview for minimized to tray apps and corresponding windows. E.g. Sleek used as a minimized to tray app

Also fixes #1094 - remove the duplicate app icons introduced by adding skip task bar windows. This also makes skip-task-bar windows behave as if they are normal icons on the switcher (if have multiple associated windows, they get the same treatment as normal - shows an arrow icon when Sleek has multiple open instances)

On Gnome 4x:
![image](https://user-images.githubusercontent.com/348125/143611121-07fbe3f7-36aa-43f5-a0b5-b76a1af34f3c.png)

On Gnome 3x:
![image](https://user-images.githubusercontent.com/348125/143611961-ef978ce2-1be5-4bc7-a924-c01f486b15b8.png)

