### PR TITLE
fix: remove transitions when opening window

### DIFF
--- a/src/window.ts
+++ b/src/window.ts
@@ -332,6 +332,7 @@ export class ShellWindow {
             meta.unmaximize(Meta.MaximizeFlags.HORIZONTAL);
             meta.unmaximize(Meta.MaximizeFlags.VERTICAL);
             meta.unmaximize(Meta.MaximizeFlags.HORIZONTAL | Meta.MaximizeFlags.VERTICAL);
+            actor.remove_all_transitions();
 
             const entity_string = String(this.entity);
             ext.movements.insert(this.entity, clone);


### PR DESCRIPTION
Just an attempt. Perhaps fixes #1232.
Replicable when Launch new instance extension installed on Fedora with 41. Then spam opening Files from clicking on Dash

I think it is happening when the window was always maximized before. And pop-shell tries to unmax it during the tiling and the window is still _moving_.