### PR TITLE
Fix workspace moving in Gnome 40

### DIFF
--- a/keybindings/10-pop-shell-move.xml
+++ b/keybindings/10-pop-shell-move.xml
@@ -8,6 +8,8 @@
   <KeyListEntry name="tile-move-up" description="Move window up"/>
   <KeyListEntry name="pop-workspace-down" description="Move window to lower workspace"/>
   <KeyListEntry name="pop-workspace-up" description="Move window to upper workspace"/>
+  <KeyListEntry name="pop-workspace-left" description="Move window to left workspace"/>
+  <KeyListEntry name="pop-workspace-righ" description="Move window to right workspace"/>
   <KeyListEntry name="pop-monitor-down" description="Move window to lower monitor"/>
   <KeyListEntry name="pop-monitor-left" description="Move window to leftward monitor"/>
   <KeyListEntry name="pop-monitor-right" description="Move window to rightward monitor"/>

--- a/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
@@ -202,6 +202,16 @@
             <summary>Move window to the upper workspace</summary>
         </key>
 
+        <key type="as" name="pop-workspace-righ">
+            <default><![CDATA[['<Super><Shift>Right','<Super><Shift>KP_Right','<Super><Shift>l']]]></default>
+            <summary>Move window to the right workspace</summary>
+        </key>
+
+        <key type="as" name="pop-workspace-left">
+            <default><![CDATA[['<Super><Shift>Left','<Super><Shift>KP_Left','<Super><Shift>h']]]></default>
+            <summary>Move window to the left workspace</summary>
+        </key>
+
         <key type="as" name="pop-monitor-down">
             <default><![CDATA[['<Super><Shift><Primary>Down','<Super><Shift><Primary>KP_Down','<Super><Shift><Primary>j']]]></default>
             <summary>Move window to the lower monitor</summary>

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -74,6 +74,10 @@ set_keybindings() {
     dconf write ${KEYS_GNOME_WM}/switch-to-workspace-down "['<Primary><Super>Down','<Primary><Super>${down}']"
     # Move to workspace above
     dconf write ${KEYS_GNOME_WM}/switch-to-workspace-up "['<Primary><Super>Up','<Primary><Super>${up}']"
+    # Move to workspace left
+    dconf write ${KEYS_GNOME_WM}/switch-to-workspace-left "['<Primary><Super>Left','<Primary><Super>${left}']"
+    # Move to workspace right
+    dconf write ${KEYS_GNOME_WM}/switch-to-workspace-right "['<Primary><Super>Right','<Primary><Super>${right}']"
 
     # Disable tiling to left / right of screen
     dconf write ${KEYS_MUTTER}/toggle-tiled-left "@as []"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1183,7 +1183,6 @@ export class Ext extends Ecs.System<ExtEvent> {
         if (!win) return;
         if (win && win.meta.is_fullscreen())
             win.meta.unmake_fullscreen();
-
         /** Move a window between workspaces */
         const workspace_move = (direction: Meta.MotionDirection) => {
             const ws = win.meta.get_workspace();
@@ -1215,13 +1214,13 @@ export class Ext extends Ecs.System<ExtEvent> {
 
             if (neighbor && neighbor.index() !== ws.index()) {
                 move_to_neighbor(neighbor);
-            } else if (direction === Meta.MotionDirection.DOWN && !last_window()) {
+            } else if ((direction === Meta.MotionDirection.DOWN || direction === Meta.MotionDirection.RIGHT) && !last_window()) {
                 if (this.settings.dynamic_workspaces()) {
                     neighbor = wom.append_new_workspace(false, global.get_current_time());
                 } else {
                     return;
                 }
-            } else if (direction === Meta.MotionDirection.UP && ws.index() === 0) {
+            } else if ((direction === Meta.MotionDirection.UP || direction === Meta.MotionDirection.LEFT) && ws.index() === 0) {
                 if (this.settings.dynamic_workspaces()) {
                     // Add a new workspace, to push everyone to free up the first one
                     wom.append_new_workspace(false, global.get_current_time());
@@ -1258,6 +1257,14 @@ export class Ext extends Ecs.System<ExtEvent> {
 
             case Meta.DisplayDirection.UP:
                 workspace_move(Meta.MotionDirection.UP)
+                break;
+
+            case Meta.DisplayDirection.RIGHT:
+                workspace_move(Meta.MotionDirection.RIGHT)
+                break;
+
+            case Meta.DisplayDirection.LEFT:
+                workspace_move(Meta.MotionDirection.LEFT)
                 break;
         }
 

--- a/src/keybindings.ts
+++ b/src/keybindings.ts
@@ -53,7 +53,11 @@ export class Keybindings {
 
             "pop-workspace-up": () => ext.move_workspace(Meta.DisplayDirection.UP),
 
-            "pop-workspace-down": () => ext.move_workspace(Meta.DisplayDirection.DOWN)
+            "pop-workspace-down": () => ext.move_workspace(Meta.DisplayDirection.DOWN),
+
+            "pop-workspace-left": () => ext.move_workspace(Meta.DisplayDirection.LEFT),
+
+            "pop-workspace-righ": () => ext.move_workspace(Meta.DisplayDirection.RIGHT)
         };
     }
 


### PR DESCRIPTION
- In Gnome 40, workspaces are organized horizontally rather than
  vertically. Thus, we need to handle moving left and right as well as 
  up and down

Fixes https://github.com/pop-os/shell/issues/1128

-------

This seems to be a move in the right direction but there are still some bugs. It works most of the time but, occasionally, moving a window will stop working. Usually in only one direction (ie, I'll be able to move windows to the right workspace, but not back to the left or vice versa). When this happens, it's because `move_workspace` is not being called. 

I'll continue debugging on my end but I have zero experience in gnome extension development so I'm putting this up with the thought that others who are interested in #1128 might have more success than me in figuring out the remaining problems.