### PR TITLE
Uncomment import of log utility in utils

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@ const Me = imports.misc.extensionUtils.getCurrentExtension();
 
 import * as result from 'result';
 import * as error from 'error';
-// import * as log from 'log';
+import * as log from 'log';
 
 const { Gio, GLib, GObject, Meta } = imports.gi;
 const { Ok, Err } = result;


### PR DESCRIPTION
Until now when installing pop-os shell into gnome-shell 3.36.9 provided
by canonical the launcher would crash with the error `log.error is not
defined` in journalctl.

The error seems to be that the import of the logging utility (`log.js`)
was never uncommented  `src/utils.js` even thought it's functionality is used. 
Doing so will solve that problem and the launcher is able to start up.

This fixes #1191