### PR TITLE
docs: Added necessary dependency (xprop) for Fedora package

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If you want to uninstall the extension, you may invoke `make uninstall`, and the
 
 ### Packaging status
 
-- [Fedora](https://src.fedoraproject.org/rpms/gnome-shell-extension-pop-shell/): `sudo dnf install gnome-shell-extension-pop-shell`
+- [Fedora](https://src.fedoraproject.org/rpms/gnome-shell-extension-pop-shell/): `sudo dnf install gnome-shell-extension-pop-shell xprop`
 - [Gentoo](https://packages.gentoo.org/packages/gnome-extra/gnome-shell-extension-pop-shell): `emerge gnome-shell-extension-pop-shell`
 - [openSUSE Tumbleweed](https://build.opensuse.org/package/show/openSUSE:Factory/gnome-shell-extension-pop-shell): `sudo zypper install gnome-shell-extension-pop-shell`
 - [Arch Linux](https://aur.archlinux.org/packages/?O=0&K=gnome-shell-extension-pop-shell) (Using Yay as AUR helper):


### PR DESCRIPTION
Updated README.md. The Fedora package doesn't pull in xprop which is necessary for this extension to tile properly. If xprop is not installed, pop-os-shell silently fails. Going to test and see if I can get Pop-os-shell to fail a bit more verbosely so that a normal warning will appear in the gnome extensions menu.