### PR TITLE
fix: Compare correct coordinates when moving window to left monitor

### DIFF
--- a/src/tiling.ts
+++ b/src/tiling.ts
@@ -819,7 +819,7 @@ export function locate_monitor(win: window.ShellWindow, direction: Meta.DisplayD
         exclude = (rect: Rectangular) => rect.y < ref.y
     } else if (direction === LEFT) {
         origin = [ref.x, ref.y + ref.height / 2]
-        exclude = (rect: Rectangular) => rect.x > ref.y
+        exclude = (rect: Rectangular) => rect.x > ref.x
     } else {
         origin = [ref.x + ref.width, ref.y + ref.height / 2]
         exclude = (rect: Rectangular) => rect.x < ref.x


### PR DESCRIPTION
This fixes #870, where windows could be moved to the right but not to the left monitor.
The root cause seems to be a small typo in the `locate_monitor` function, where only for the move left case the wrong pair of coordinates is compared.
The fix is therefore quite simple.