### PR TITLE
fix: Close search window on 'WindowQuit'

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -262,6 +262,7 @@ export class Ext extends Ecs.System<ExtEvent> {
 
         this.dbus.WindowQuit = (win: [number, number]) => {
             this.windows.get(win)?.meta.delete(global.get_current_time())
+            this.window_search.close()
         }
     }
 


### PR DESCRIPTION
This is related to #1278 and [my pull request on pop-os/launcher](https://github.com/pop-os/launcher/pull/75).

When receiving a call to `WindowQuit`, the launcher window currently stays open after the requested window is closed. The entry list in the launcher window is not updated however, with the entry for the now closed window still being present.

This change causes the launcher window to close after each `WindowQuit` call, which should be the same behavior as was implemented [before adapting the Rust launcher implementation](https://github.com/pop-os/shell/blob/e83443e96ba914f3ef990e3e410a0dbe39f11c58/src/dialog_launcher.ts#L312).