### PR TITLE
add re.sonny.Junction to DEFAULT_FLOAT_RULES

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -49,7 +49,8 @@ export const DEFAULT_FLOAT_RULES: Array<FloatRule> = [
     { class: "Steam", title: "^.*(Guard|Login).*" },
     { class: "krunner" },
     { class: "ibus-.*" },
-    { class: "gjs" }
+    { class: "gjs" },
+    { class: "re.sonny.Junction" }
 ];
 
 export interface WindowRule {


### PR DESCRIPTION
The [Junction app](https://flathub.org/apps/details/re.sonny.Junction) for choosing a web browser when clicking on links should be excluded from tiling by default.

Also: should this list be alphabetical?