### PR TITLE
fix: On destroy of stacked window, activate previously active tab

### DIFF
--- a/src/forest.ts
+++ b/src/forest.ts
@@ -717,18 +717,15 @@ export class Forest extends Ecs.World {
 
             // Activate the next window in the stack if the window was destroyed.
             if (idx !== null) {
-                let activate = idx > 0 ? idx - 1 : 0;
-                const entity = stack.entities[activate];
-
-                if (entity) {
-                    ext.register_fn(() => {
-                        this.stacks.get(stack.idx)?.activate(entity)
+                ext.register_fn(() => {
+                    const s = this.stacks.get(stack.idx);
+                    if (s && s.prev_active) {
+                        s.activate(s.prev_active)
                         if (!ext.windows.contains(window)) {
-                            ext.windows.with(entity, (win) => win.activate(false))
+                            ext.windows.with(s.prev_active, (win) => win.activate(false))
                         }
-
-                    })
-                }
+                    }
+                })
             }
         }
 

--- a/src/stack.ts
+++ b/src/stack.ts
@@ -51,6 +51,9 @@ export class Stack {
 
     active_id: number = 0
 
+    prev_active: null | Entity = null;
+    prev_active_id: number = 0;
+
     tabs: Array<Tab> = new Array();
 
     monitor: number;
@@ -127,6 +130,16 @@ export class Stack {
 
     /** Activates the tab of this entity */
     activate(entity: Entity) {
+        if (this.prev_active && Ecs.entity_eq(entity, this.prev_active)) {
+            this.prev_active = null
+            this.prev_active_id = 0
+        } else if (!Ecs.entity_eq(entity, this.active)) {
+            if (this.prev_active == null || !Ecs.entity_eq(entity, this.prev_active)) {
+                this.prev_active = this.active;
+                this.prev_active_id = this.active_id;
+            }
+        }
+
         const permitted = this.permitted_to_show()
 
         if (this.widgets) this.widgets.tabs.visible = permitted;
@@ -394,6 +407,11 @@ export class Stack {
     /** Removes the tab associated with the entity */
     remove_tab(entity: Entity): null | number {
         if (!this.widgets) return null;
+
+        if (this.prev_active && Ecs.entity_eq(entity, this.prev_active)) {
+            this.prev_active = null
+            this.prev_active_id = 0
+        }
 
         let idx = 0;
         for (const c of this.tabs) {


### PR DESCRIPTION
Useful when a web browser has a popup window and then that popup is closed

Or when testing GTK applications from an IDE