### PR TITLE
chore: Mark Discord initial updater pop-up as floating

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -26,6 +26,7 @@ export const DEFAULT_FLOAT_RULES: Array<FloatRule> = [
     { class: "Com.github.amezin.ddterm" },
     { class: "Com.github.donadigo.eddy" },
     { class: "Conky" },
+    { title: "Discord Updater" },
     { class: "Enpass", title: "Enpass Assistant" },
     { class: "Floating Window Exceptions" },
     { class: "Gjs", title: "Settings" },


### PR DESCRIPTION
Using just `title` seems more idiomatic, but I can see that other exceptions keep using `class` to refer to titles? Let me know if I should change that.