### PR TITLE
fix: entity is null on window destroy from stack

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -747,6 +747,8 @@ export class Ext extends Ecs.System<ExtEvent> {
         const window = this.windows.get(win);
         if (!window) return;
 
+        window.destroying = true;
+
         // Disconnect all signals on this window
         this.window_signals.take_with(win, (signals) => {
             for (const signal of signals) {
@@ -1836,7 +1838,7 @@ export class Ext extends Ecs.System<ExtEvent> {
                         } else if (!meta_window.is_override_redirect()) {
                             // This section fixes Steam's sub-menus.
                             meta_window.activate(global.get_current_time())
-                        }                        
+                        }
                     } else if (this.auto_tiler) {
                         // Re-focus a window that was unfocused.
                         let entity: Ecs.Entity | null = null

--- a/src/forest.ts
+++ b/src/forest.ts
@@ -716,16 +716,28 @@ export class Forest extends Ecs.World {
             const idx = Node.stack_remove(this, stack, window);
 
             // Activate the next window in the stack if the window was destroyed.
-            if (idx !== null) {
-                ext.register_fn(() => {
-                    const s = this.stacks.get(stack.idx);
-                    if (s && s.prev_active) {
-                        s.activate(s.prev_active)
-                        if (!ext.windows.contains(window)) {
-                            ext.windows.with(s.prev_active, (win) => win.activate(false))
+            const win = ext.windows.get(window)
+            if (idx !== null && win && win.destroying) {
+                const s = this.stacks.get(stack.idx);
+                if (s) {
+                    if (s.prev_active) {
+                        const win = ext.windows.get(s.prev_active)
+                        if (win) {
+                            s.activate(s.prev_active)
+                            win.activate(false)
                         }
+
+                        return
                     }
-                })
+
+                    const activate = idx > 0 ? idx - 1 : 0;
+                    const entity = stack.entities[activate];
+                    const win = ext.windows.get(entity)
+                    if (win) {
+                        s.activate(entity)
+                        win.activate(false)
+                    }
+                }
             }
         }
 

--- a/src/window.ts
+++ b/src/window.ts
@@ -55,6 +55,7 @@ export class ShellWindow {
     activate_after_move: boolean = false;
     ignore_detach: boolean = false;
     was_attached_to?: [Entity, boolean | number];
+    destroying: boolean = false;
 
     // Awaiting reassignment after a display update
     reassignment: boolean = false


### PR DESCRIPTION
Fixes regression from last commit that causes tiling to stop working when an entity null error is triggered. It occasionally happens when two stacks are active, windows are added to both, and focus is shifted back and forth while removing and adding windows.