### PR TITLE
fix: On destroy of stacked window, activate previously active tab

### DIFF
--- a/src/forest.ts
+++ b/src/forest.ts
@@ -713,31 +713,16 @@ export class Forest extends Ecs.World {
             this.stacks.remove(stack.idx)?.destroy();
             on_last();
         } else {
-            const idx = Node.stack_remove(this, stack, window);
-
-            // Activate the next window in the stack if the window was destroyed.
-            const win = ext.windows.get(window)
-            if (idx !== null && win && win.destroying) {
-                const s = this.stacks.get(stack.idx);
-                if (s) {
-                    if (s.prev_active) {
-                        const win = ext.windows.get(s.prev_active)
-                        if (win) {
-                            s.activate(s.prev_active)
-                            win.activate(false)
-                        }
-
-                        return
-                    }
-
-                    const activate = idx > 0 ? idx - 1 : 0;
-                    const entity = stack.entities[activate];
-                    const win = ext.windows.get(entity)
-                    if (win) {
-                        s.activate(entity)
-                        win.activate(false)
-                    }
+            const s = this.stacks.get(stack.idx)
+            if (s) {
+                const win = ext.windows.get(window)
+                if (win && win.destroying) {
+                    s.activate_prev()
+                    ext.windows.get(s.active)?.activate()
+                    ext.register_fn(() => ext.windows.get(s.active)?.activate())
                 }
+
+                Node.stack_remove(this, stack, window)
             }
         }
 

--- a/src/stack.ts
+++ b/src/stack.ts
@@ -128,18 +128,14 @@ export class Stack {
         return c.entity;
     }
 
+    activate_prev() {
+        if (this.prev_active) {
+            this.activate(this.prev_active)
+        }
+    }
+
     /** Activates the tab of this entity */
     activate(entity: Entity) {
-        if (this.prev_active && Ecs.entity_eq(entity, this.prev_active)) {
-            this.prev_active = null
-            this.prev_active_id = 0
-        } else if (!Ecs.entity_eq(entity, this.active)) {
-            if (this.prev_active == null || !Ecs.entity_eq(entity, this.prev_active)) {
-                this.prev_active = this.active;
-                this.prev_active_id = this.active_id;
-            }
-        }
-
         const permitted = this.permitted_to_show()
 
         if (this.widgets) this.widgets.tabs.visible = permitted;
@@ -148,6 +144,11 @@ export class Stack {
 
         const win = this.ext.windows.get(entity);
         if (!win) return;
+
+        if (!Ecs.entity_eq(entity, this.active)) {
+            this.prev_active = this.active
+            this.prev_active_id = this.active_id
+        }
 
         this.active_connect(win.meta, entity);
 


### PR DESCRIPTION
Can be tested by launching an application from a terminal, and then closing the application should switch back to the terminal that spawned it, regardless of its position in the stack.