### PR TITLE
chore: Mark Ubuntu Software Updater as floating window

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -36,6 +36,7 @@ export const DEFAULT_FLOAT_RULES: Array<FloatRule> = [
     { class: "Io.elementary.sideload" },
     { class: "KotatogramDesktop", title: "Media viewer" },
     { class: "Mozilla VPN" },
+    { title: "Software Updater" },
     { class: "Solaar" },
     { class: "Steam", title: "^((?!Steam).)*$" },
     { class: "Steam", title: "^.*(Guard|Login).*" },


### PR DESCRIPTION
Similar to #1363

The name seems to be generic enough that it probably warrants specifying the class as well, but I'm no GTK developer and I have no idea how to get app id from a window on window select/hover... could you help me by pointing me in the right direction?

### Reproduction
Run `update-manager`

### Screenshots

Before:
![Screenshot from 2022-03-08 13-18-08](https://user-images.githubusercontent.com/3093213/157237163-b900fc45-4e99-4e09-8239-199dacda4fbe.png)

After:
![Screenshot from 2022-03-08 13-17-33](https://user-images.githubusercontent.com/3093213/157237210-74abf9be-569f-4c7d-898c-613122de54b9.png)

