### PR TITLE
fix: make sure to enable user extensions

### DIFF
--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -106,6 +106,9 @@ fi
 
 set_keybindings
 
+# Make sure user extensions are enabled
+dconf write /org/gnome/shell/disable-user-extensions false
+
 # Use a window placement behavior which works better for tiling
 
 if gnome-extensions list | grep native-window; then


### PR DESCRIPTION
If the extension is installed with `make local-install` to `~/./local/share/gnome-shell/extensions/`, it is now ensured that user extensions are enabled.
Improved version of pull request [#1361](https://github.com/pop-os/shell/pull/1361) 