### PR TITLE
Re-apply window title on/off after screen unlocking

### DIFF
--- a/src/dbus_service.ts
+++ b/src/dbus_service.ts
@@ -25,6 +25,7 @@ const IFACE: string = `<node>
 export class Service {
     dbus: any
     id: any
+    handlerScsvWakeUp: any; // Handler id from DBus signal subscription (need to unsubscribe on destroy)
 
     FocusLeft: () => void = () => {}
     FocusRight: () => void = () => {}
@@ -34,6 +35,7 @@ export class Service {
     WindowFocus: (window: [number, number]) => void = () => {}
     WindowList: () => Array<[[number, number], string, string, string]> = () => []
     WindowQuit: (window: [number, number]) => void = () => {}
+    onScsvActiveChanged: (params: any) => void = () => {}
 
     constructor() {
         this.dbus = Gio.DBusExportedObject.wrapJSObject(IFACE, this)
@@ -54,9 +56,21 @@ export class Service {
             onNameAcquired,
             onNameLost
         )
+
+        try {
+            this.handlerScsvWakeUp = Gio.DBus.session.signal_subscribe('org.gnome.ScreenSaver', 'org.gnome.ScreenSaver', 'ActiveChanged', '/org/gnome/ScreenSaver', null, Gio.DBusSignalFlags.NONE,
+                    (_conn:any, _sender:any, _path:any, _iface:any, _signal:any, params:any) => this.onScsvActiveChanged(params));
+        }catch(e) {
+            log.error(e, 'failed to subscribe to Screensaver ActiveChanged signal');
+        }
     }
 
     destroy() {
+        try {
+            Gio.DBus.session.signal_unsubscribe(this.handlerScsvWakeUp);
+        }catch(e) {
+            log.error(e, 'failed to unsubscribe from Screensaver ActiveChanged signal');
+        }
         Gio.bus_unown_name(this.id)
     }
 }

--- a/src/events.ts
+++ b/src/events.ts
@@ -11,7 +11,7 @@ export type ExtEvent = GenericCallback
     | CreateWindow
     | GlobalEventTag;
 
-/** Eevnt with generic callback */
+/** Event with generic callback */
 export interface GenericCallback {
     tag: 1;
     callback: () => void;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -74,6 +74,7 @@ interface Injection {
     func: any;
 }
 
+/** The pop-shell Gnome extension class */
 export class Ext extends Ecs.System<ExtEvent> {
     /** Mechanism for managing keybindings */
     keybindings: Keybindings.Keybindings = new Keybindings.Keybindings(this);
@@ -262,6 +263,14 @@ export class Ext extends Ecs.System<ExtEvent> {
         this.dbus.WindowQuit = (win: [number, number]) => {
             this.windows.get(win)?.meta.delete(global.get_current_time())
             this.window_search.close()
+        }
+
+        this.dbus.onScsvActiveChanged = (params) => {
+            const value = params.get_child_value(0);
+            const locked = value.get_boolean();
+            log.debug(`Screen Locked: ${locked}`);
+            if(!locked)
+                this.on_show_window_titles(); // Window titles on/off is lost after screensaver unlocking, re-apply it
         }
     }
 


### PR DESCRIPTION
Before this change the window titles were still visible after
unlocking the screen, even if the setting was to off.