### PR TITLE
chore: add Pritunl client to floating exceptions

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -50,11 +50,11 @@ export const DEFAULT_FLOAT_RULES: Array<FloatRule> = [
     { class: "jetbrains-webstorm", title: "License Activation" },
     { class: "jetbrains-webstorm", title: "Welcome to WebStorm" },
     { class: "krunner" },
+    { class: "pritunl" },
     { class: "re.sonny.Junction" },
     { class: "system76-driver" },
     { class: "tilda" },
-    { class: "zoom" },
-    { class: "pritunl" }
+    { class: "zoom" }
 
 ];
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -53,7 +53,8 @@ export const DEFAULT_FLOAT_RULES: Array<FloatRule> = [
     { class: "re.sonny.Junction" },
     { class: "system76-driver" },
     { class: "tilda" },
-    { class: "zoom" }
+    { class: "zoom" },
+    { class: "pritunl" }
 
 ];
 


### PR DESCRIPTION
Pritunl desktop is a non-resizeable electron app. Adding it via Floating Window Exceptions works fine but this will save people a config step