### PR TITLE
[jammy] fix: On Gnome 42, close launcher on click outside of it

### DIFF
--- a/src/search.ts
+++ b/src/search.ts
@@ -206,7 +206,7 @@ export class Search {
         // Ensure that the width is at least 640 pixels wide.
         this.dialog.contentLayout.width = Math.max(Lib.current_monitor().width / 4, 640);
 
-        const id = global.stage.connect('event', (_actor: any, event: any) => {
+        this.dialog.connect('event', (_actor: any, event: any) => {
             const { width, height } = this.dialog.dialogLayout._dialog;
             const { x, y } = this.dialog.dialogLayout
             const area = new rect.Rectangle([x, y, width, height]);
@@ -225,7 +225,6 @@ export class Search {
         })
 
         this.dialog.connect('closed', () => this.cancel())
-        this.dialog.connect('destroy', () => global.stage.disconnect(id))
     }
 
     cleanup() {


### PR DESCRIPTION
Fixes https://github.com/pop-os/shell/issues/1386.

This breaks the behavior on older Gnome Shell versions. If we want this branch to work there as well, it would be easy to make it conditional.

I don't know if there are any other undesired behavior changes here or the other places `shellReactive: true` is used, but it seems to basically work as expected now.