### PR TITLE
fix: make sure to enable user extensions

### DIFF
--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -106,6 +106,9 @@ fi
 
 set_keybindings
 
+# Make sure user extensions are enabled
+dconf write /org/gnome/shell/disable-user-extensions false
+
 # Use a window placement behavior which works better for tiling
 
 if gnome-extensions list | grep native-window; then


### PR DESCRIPTION
Applies https://github.com/pop-os/shell/pull/1368 to Jammy, since it was merged into master for older releases.

Note for QA, this `configure.sh` script is only used for local installations, not for the official Pop!_OS .deb packaging.