### PR TITLE
Feature: Add option to disable moving mouse cursor on keyboard navigation

### DIFF
--- a/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
@@ -27,6 +27,11 @@
             <summary>Handle minimized to tray windows</summary>
         </key>
 
+        <key type="b" name="move-cursor-on-switch">
+            <default>true</default>
+            <summary>Move cursor to active window when switching via keyboard shortcuts</summary>
+        </key>
+
         <!-- Tiling Options -->
         <key type="u" name="column-size">
             <default>64</default>

--- a/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
@@ -27,9 +27,9 @@
             <summary>Handle minimized to tray windows</summary>
         </key>
 
-        <key type="b" name="move-cursor-on-switch">
+        <key type="b" name="mouse-cursor-follows-active-window">
             <default>true</default>
-            <summary>Move cursor to active window when switching via keyboard shortcuts</summary>
+            <summary>Move cursor to active window when navigating with keyboard shortcuts or touchpad gestures</summary>
         </key>
 
         <!-- Tiling Options -->

--- a/src/config.ts
+++ b/src/config.ts
@@ -101,9 +101,6 @@ export class Config {
     /** Logs window details on focus of window */
     log_on_focus: boolean = false;
 
-    /** Move pointer when you switch applications */
-    move_pointer_on_switch: boolean = false;
-
     /** Specify default pointer position when you're switching windows */
     default_pointer_position: DefaultPointerPosition = DefaultPointerPosition.TopLeft;
 
@@ -180,7 +177,6 @@ export class Config {
             this.float = c.float;
             this.log_on_focus = c.log_on_focus;
             this.default_pointer_position = c.default_pointer_position;
-            this.move_pointer_on_switch = c.move_pointer_on_switch;
         } else {
             log(`error loading conf: ${conf.why}`)
         }

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -18,6 +18,7 @@ interface AppWidgets {
     snap_to_grid: any,
     window_titles: any,
     show_skip_taskbar: any,
+    move_cursor_on_switch: any,
 }
 
 // @ts-ignore
@@ -70,6 +71,12 @@ function settings_dialog_new(): Gtk.Container {
         Settings.sync();
     });
 
+    app.move_cursor_on_switch.set_active(ext.move_cursor_on_switch());
+    app.move_cursor_on_switch.connect('state-set', (_widget: any, state: boolean) => {
+        ext.set_move_cursor_on_switch(state);
+        Settings.sync();
+    });
+
     return grid;
 }
 
@@ -103,11 +110,17 @@ function settings_dialog_view(): [AppWidgets, Gtk.Container] {
         label: "Show Minimize to Tray Windows",
         xalign: 0.0
     });
+
+    let move_cursor_on_switch_label = new Gtk.Label({
+        label: "Move Mouse Cursor when Switching",
+        xalign: 0.0
+    });
     
     let window_titles = new Gtk.Switch({ halign: Gtk.Align.END });
     let snap_to_grid = new Gtk.Switch({ halign: Gtk.Align.END });
     let smart_gaps = new Gtk.Switch({ halign: Gtk.Align.END });
     let show_skip_taskbar = new Gtk.Switch({ halign: Gtk.Align.END });
+    let move_cursor_on_switch = new Gtk.Switch({ halign: Gtk.Align.END });
 
     grid.attach(win_label, 0, 0, 1, 1);
     grid.attach(window_titles, 1, 0, 1, 1);
@@ -121,11 +134,14 @@ function settings_dialog_view(): [AppWidgets, Gtk.Container] {
     grid.attach(show_skip_taskbar_label, 0, 3, 1, 1);
     grid.attach(show_skip_taskbar, 1, 3, 1, 1);
 
-    logging_combo(grid, 4);
+    grid.attach(move_cursor_on_switch_label, 0, 4, 1, 1);
+    grid.attach(move_cursor_on_switch, 1, 4, 1, 1);
 
-    let [inner_gap, outer_gap] = gaps_section(grid, 5);
+    logging_combo(grid, 5);
 
-    let settings = { inner_gap, outer_gap, smart_gaps, snap_to_grid, window_titles, show_skip_taskbar };
+    let [inner_gap, outer_gap] = gaps_section(grid, 6);
+
+    let settings = { inner_gap, outer_gap, smart_gaps, snap_to_grid, window_titles, show_skip_taskbar, move_cursor_on_switch };
 
     return [settings, grid];
 }

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -18,7 +18,7 @@ interface AppWidgets {
     snap_to_grid: any,
     window_titles: any,
     show_skip_taskbar: any,
-    move_cursor_on_switch: any,
+    mouse_cursor_follows_active_window: any,
 }
 
 // @ts-ignore
@@ -71,9 +71,9 @@ function settings_dialog_new(): Gtk.Container {
         Settings.sync();
     });
 
-    app.move_cursor_on_switch.set_active(ext.move_cursor_on_switch());
-    app.move_cursor_on_switch.connect('state-set', (_widget: any, state: boolean) => {
-        ext.set_move_cursor_on_switch(state);
+    app.mouse_cursor_follows_active_window.set_active(ext.mouse_cursor_follows_active_window());
+    app.mouse_cursor_follows_active_window.connect('state-set', (_widget: any, state: boolean) => {
+        ext.set_mouse_cursor_follows_active_window(state);
         Settings.sync();
     });
 
@@ -111,8 +111,8 @@ function settings_dialog_view(): [AppWidgets, Gtk.Container] {
         xalign: 0.0
     });
 
-    let move_cursor_on_switch_label = new Gtk.Label({
-        label: "Move Mouse Cursor when Switching",
+    let mouse_cursor_follows_active_window_label = new Gtk.Label({
+        label: "Mouse Cursor Follows Active Window",
         xalign: 0.0
     });
     
@@ -120,7 +120,7 @@ function settings_dialog_view(): [AppWidgets, Gtk.Container] {
     let snap_to_grid = new Gtk.Switch({ halign: Gtk.Align.END });
     let smart_gaps = new Gtk.Switch({ halign: Gtk.Align.END });
     let show_skip_taskbar = new Gtk.Switch({ halign: Gtk.Align.END });
-    let move_cursor_on_switch = new Gtk.Switch({ halign: Gtk.Align.END });
+    let mouse_cursor_follows_active_window = new Gtk.Switch({ halign: Gtk.Align.END });
 
     grid.attach(win_label, 0, 0, 1, 1);
     grid.attach(window_titles, 1, 0, 1, 1);
@@ -134,14 +134,14 @@ function settings_dialog_view(): [AppWidgets, Gtk.Container] {
     grid.attach(show_skip_taskbar_label, 0, 3, 1, 1);
     grid.attach(show_skip_taskbar, 1, 3, 1, 1);
 
-    grid.attach(move_cursor_on_switch_label, 0, 4, 1, 1);
-    grid.attach(move_cursor_on_switch, 1, 4, 1, 1);
+    grid.attach(mouse_cursor_follows_active_window_label, 0, 4, 1, 1);
+    grid.attach(mouse_cursor_follows_active_window, 1, 4, 1, 1);
 
     logging_combo(grid, 5);
 
     let [inner_gap, outer_gap] = gaps_section(grid, 6);
 
-    let settings = { inner_gap, outer_gap, smart_gaps, snap_to_grid, window_titles, show_skip_taskbar, move_cursor_on_switch };
+    let settings = { inner_gap, outer_gap, smart_gaps, snap_to_grid, window_titles, show_skip_taskbar, mouse_cursor_follows_active_window };
 
     return [settings, grid];
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -60,7 +60,7 @@ const HINT_COLOR_RGBA = "hint-color-rgba";
 const DEFAULT_RGBA_COLOR = "rgba(251, 184, 108, 1)"; //pop-orange
 const LOG_LEVEL = "log-level";
 const SHOW_SKIPTASKBAR = "show-skip-taskbar";
-const MOVE_CURSOR_ON_SWITCH = "move-cursor-on-switch"
+const MOUSE_CURSOR_FOLLOWS_ACTIVE_WINDOW = "mouse-cursor-follows-active-window"
 
 export class ExtensionSettings {
     ext: Settings = settings_new_schema(Me.metadata["settings-schema"]);
@@ -152,8 +152,8 @@ export class ExtensionSettings {
         return this.ext.get_boolean(SHOW_SKIPTASKBAR);
     }
 
-    move_cursor_on_switch(): boolean {
-        return this.ext.get_boolean(MOVE_CURSOR_ON_SWITCH);
+    mouse_cursor_follows_active_window(): boolean {
+        return this.ext.get_boolean(MOUSE_CURSOR_FOLLOWS_ACTIVE_WINDOW);
     }
 
     // Setters
@@ -212,7 +212,7 @@ export class ExtensionSettings {
         this.ext.set_boolean(SHOW_SKIPTASKBAR, set);
     }
 
-    set_move_cursor_on_switch(set: boolean) {
-        this.ext.set_boolean(MOVE_CURSOR_ON_SWITCH, set);
+    set_mouse_cursor_follows_active_window(set: boolean) {
+        this.ext.set_boolean(MOUSE_CURSOR_FOLLOWS_ACTIVE_WINDOW, set);
     }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -60,6 +60,7 @@ const HINT_COLOR_RGBA = "hint-color-rgba";
 const DEFAULT_RGBA_COLOR = "rgba(251, 184, 108, 1)"; //pop-orange
 const LOG_LEVEL = "log-level";
 const SHOW_SKIPTASKBAR = "show-skip-taskbar";
+const MOVE_CURSOR_ON_SWITCH = "move-cursor-on-switch"
 
 export class ExtensionSettings {
     ext: Settings = settings_new_schema(Me.metadata["settings-schema"]);
@@ -151,6 +152,10 @@ export class ExtensionSettings {
         return this.ext.get_boolean(SHOW_SKIPTASKBAR);
     }
 
+    move_cursor_on_switch(): boolean {
+        return this.ext.get_boolean(MOVE_CURSOR_ON_SWITCH);
+    }
+
     // Setters
 
     set_active_hint(set: boolean) {
@@ -205,5 +210,9 @@ export class ExtensionSettings {
 
     set_show_skiptaskbar(set: boolean) {
         this.ext.set_boolean(SHOW_SKIPTASKBAR, set);
+    }
+
+    set_move_cursor_on_switch(set: boolean) {
+        this.ext.set_boolean(MOVE_CURSOR_ON_SWITCH, set);
     }
 }

--- a/src/window.ts
+++ b/src/window.ts
@@ -113,7 +113,7 @@ export class ShellWindow {
     }
 
     activate(move_mouse: boolean = true): void {
-        activate(move_mouse, this.ext.conf.default_pointer_position, this.meta);
+        activate(this.ext, move_mouse, this.ext.conf.default_pointer_position, this.meta);
     }
 
     actor_exists(): boolean {
@@ -606,7 +606,7 @@ export class ShellWindow {
 }
 
 /// Activates a window, and moves the mouse point.
-export function activate(move_mouse: boolean, default_pointer_position: Config.DefaultPointerPosition, win: Meta.Window) {
+export function activate(ext: Ext, move_mouse: boolean, default_pointer_position: Config.DefaultPointerPosition, win: Meta.Window) {
     if (win.is_override_redirect()) return
 
     const workspace = win.get_workspace()
@@ -618,7 +618,7 @@ export function activate(move_mouse: boolean, default_pointer_position: Config.D
     workspace.activate_with_focus(win, global.get_current_time())
     win.raise()
 
-    if (move_mouse && !pointer_already_on_window(win)) {
+    if (ext.settings.move_cursor_on_switch() && move_mouse && !pointer_already_on_window(win)) {
         place_pointer_on(default_pointer_position, win)
     }
 }

--- a/src/window.ts
+++ b/src/window.ts
@@ -618,7 +618,7 @@ export function activate(ext: Ext, move_mouse: boolean, default_pointer_position
     workspace.activate_with_focus(win, global.get_current_time())
     win.raise()
 
-    if (ext.settings.move_cursor_on_switch() && move_mouse && !pointer_already_on_window(win)) {
+    if (ext.settings.mouse_cursor_follows_active_window() && move_mouse && !pointer_already_on_window(win)) {
         place_pointer_on(default_pointer_position, win)
     }
 }


### PR DESCRIPTION
This is my attempt at implementing #1188.

Do I need to add a new scenario to TESTING.md?

Does the setting summary `Move cursor to active window when switching via keyboard shortcuts` accurately describe the behaviour here?

Also looking for suggestions on the label for this setting in the settings window, it doesn't make much sense at the moment.