### PR TITLE
fix (local-install): Restart GNOME Shell before enabling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ disable:
 listen:
 	journalctl -o cat -n 0 -f "$$(which gnome-shell)" | grep -v warning
 
-local-install: depcheck compile install configure enable restart-shell
+local-install: depcheck compile install configure restart-shell enable
 
 install:
 	rm -rf $(INSTALLBASE)/$(INSTALLNAME)


### PR DESCRIPTION
`make local-install` currently gives an `Extension "pop-shell@system76.com" does not exist` error message the first time it's run on a system where Pop Shell is not installed at all (globally or locally). This is because the makefile installs Pop Shell and then tries to enable it before GNOME Shell has been restarted; GNOME Shell doesn't detect the newly-installed extension until it's been restarted, so it can't be enabled until after a restart.

This change swaps the order so the extension is installed, GNOME Shell is restarted, and then the extension is enabled last. This should fix `local-install` on systems where Pop Shell was not installed before. On systems where development is being performed, enabling after the restart should make no difference, since the extension would have already been enabled anyway.

(The extension seems to work fine on first enable after the restart; if there's a problem with doing this, the alternative solution would be restarting GNOME Shell twice during `local-install`, once before `enable` and once after.)