### PR TITLE
GNOME 42 Shell Fixes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1924,7 +1924,12 @@ export class Ext extends Ecs.System<ExtEvent> {
 
             this.connect(display, 'notify::focus-window', () => {
                 // Disallow refocus if a modal window is active
-                if (Main.modalCount !== 0) return
+                if (Main.modalCount !== 0) {
+                    const { actor } = Main.modalActorFocusStack[0]
+                    if (actor.style_class !== "switcher-popup") {
+                        return
+                    }
+                }
 
                 const refocus_tiled_window = () => {
                     // Re-focus a window that was unfocused.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -522,7 +522,6 @@ export class Ext extends Ecs.System<ExtEvent> {
 
     exception_dialog() {
         let path = Me.dir.get_path() + "/floating_exceptions/main.js";
-        const cancellable = new Gio.Cancellable();
 
         const event_handler = (event: string): boolean => {
             switch (event) {
@@ -548,7 +547,7 @@ export class Ext extends Ecs.System<ExtEvent> {
                     const [bytes,] = stdout.read_line_finish(res)
                     if (bytes) {
                         if (event_handler((imports.byteArray.toString(bytes) as string).trim())) {
-                            ipc.stdout.read_line_async(0, cancellable, generator)
+                            ipc.stdout.read_line_async(0, ipc.cancellable, generator)
                         }
                     }
                 } catch (why) {
@@ -556,7 +555,7 @@ export class Ext extends Ecs.System<ExtEvent> {
                 }
             }
 
-            ipc.stdout.read_line_async(0, cancellable, generator)
+            ipc.stdout.read_line_async(0, ipc.cancellable, generator)
         }
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1891,8 +1891,6 @@ export class Ext extends Ecs.System<ExtEvent> {
                 // Disallow refocus if a modal window is active
                 if (Main.modalCount !== 0) return
 
-                global.log(`refocusing`)
-
                 const refocus_tiled_window = () => {
                     // Re-focus a window that was unfocused.
                     let window: Window.ShellWindow | null = null

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -938,11 +938,8 @@ export class Ext extends Ecs.System<ExtEvent> {
 
     show_border_on_focused() {
         this.hide_all_borders();
-
-        const focus = this.focus_window();
-        if (focus) {
-            focus.show_border();
-        }
+        const focus = this.focus_window()
+        if (focus) focus.show_border()
     }
 
     hide_all_borders() {
@@ -1894,6 +1891,8 @@ export class Ext extends Ecs.System<ExtEvent> {
             this.connect(display, 'notify::focus-window', () => {
                 // Disallow refocus if a modal window is active
                 if (Main.modalCount !== 0) return
+
+                global.log(`refocusing`)
 
                 const refocus_tiled_window = () => {
                     // Re-focus a window that was unfocused.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1904,7 +1904,11 @@ export class Ext extends Ecs.System<ExtEvent> {
                         window = this.windows.get(x)
                     }
 
-                    window?.activate(false)
+                    if (window && window.same_monitor()) {
+                        window.activate(false)
+                    } else {
+                        this.hide_all_borders()
+                    }
                 }
 
                 // Delay in case the focused window was not focused yet.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1904,7 +1904,7 @@ export class Ext extends Ecs.System<ExtEvent> {
                         window = this.windows.get(x)
                     }
 
-                    if (window && window.same_monitor()) {
+                    if (window && window.same_monitor() && window.same_workspace()) {
                         window.activate(false)
                     } else {
                         this.hide_all_borders()

--- a/src/floating_exceptions/src/main.ts
+++ b/src/floating_exceptions/src/main.ts
@@ -235,7 +235,7 @@ class App {
         win.set_default_size(550, 700)
         win.get_content_area().add(this.stack)
         win.show_all()
-        win.connect('delete-event', () => win.close())
+        win.connect('delete-event', () => Gtk.main_quit())
 
         back.hide()
 

--- a/src/forest.ts
+++ b/src/forest.ts
@@ -715,13 +715,6 @@ export class Forest extends Ecs.World {
         } else {
             const s = this.stacks.get(stack.idx)
             if (s) {
-                const win = ext.windows.get(window)
-                if (win && win.destroying) {
-                    s.activate_prev()
-                    ext.windows.get(s.active)?.activate()
-                    ext.register_fn(() => ext.windows.get(s.active)?.activate())
-                }
-
                 Node.stack_remove(this, stack, window)
             }
         }

--- a/src/launcher_service.ts
+++ b/src/launcher_service.ts
@@ -14,8 +14,6 @@ const { byteArray } = imports;
  */
 export class LauncherService {
     service: utils.AsyncIPC
-    /** When exiting the service */
-    cancellable: any = new Gio.Cancellable()
 
     constructor(service: utils.AsyncIPC, callback: (response: JsonIPC.Response) => void) {
         this.service = service
@@ -28,7 +26,7 @@ export class LauncherService {
                     const string = byteArray.toString(bytes)
                     // log.debug(`received response from launcher service: ${string}`)
                     callback(JSON.parse(string))
-                    this.service.stdout.read_line_async(0, this.cancellable, generator)
+                    this.service.stdout.read_line_async(0, this.service.cancellable, generator)
                 }
             } catch (why) {
                 // Do not print an error if it was merely cancelled.
@@ -40,7 +38,7 @@ export class LauncherService {
             }
         }
 
-        this.service.stdout.read_line_async(0, this.cancellable, generator)
+        this.service.stdout.read_line_async(0, this.service.cancellable, generator)
     }
 
     activate(id: number) {
@@ -61,7 +59,7 @@ export class LauncherService {
 
     exit() {
         this.send('Exit')
-        this.cancellable.cancel()
+        this.service.cancellable.cancel()
         const service = this.service
 
         GLib.timeout_add(GLib.PRIORITY_DEFAULT, 100, () => {

--- a/src/launcher_service.ts
+++ b/src/launcher_service.ts
@@ -31,6 +31,11 @@ export class LauncherService {
                     this.service.stdout.read_line_async(0, this.cancellable, generator)
                 }
             } catch (why) {
+                // Do not print an error if it was merely cancelled.
+                if ((why as any).matches (Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED)){
+                    return
+                }
+
                 log.error(`failed to read response from launcher service: ${why}`)
             }
         }

--- a/src/mod.d.ts
+++ b/src/mod.d.ts
@@ -8,6 +8,7 @@ interface Global {
     get_pointer(): [number, number];
     get_window_actors(): Array<Meta.WindowActor>;
     log(msg: string): void;
+    logError(error: any): void
 
     display: Meta.Display;
     run_at_leisure(func: () => void): void;

--- a/src/mod.d.ts
+++ b/src/mod.d.ts
@@ -39,6 +39,8 @@ declare type SignalID = number;
 declare interface GLib {
     PRIORITY_DEFAULT: number;
     PRIORITY_LOW: number;
+    SOURCE_REMOVE: boolean;
+    SOURCE_CONTINUE: boolean;
 
     find_program_in_path(prog: string): string | null;
     get_current_dir(): string;
@@ -53,7 +55,7 @@ declare interface GLib {
     spawn_command_line_sync(cmd: string): ProcessResult;
     spawn_command_line_async(cmd: string): boolean;
 
-    timeout_add(priority: number, ms: number, callback: () => Boolean): number;
+    timeout_add(priority: number, ms: number, callback: () => boolean): number;
 }
 
 declare namespace GObject {

--- a/src/search.ts
+++ b/src/search.ts
@@ -35,6 +35,9 @@ export class Search {
     private children_to_abandon: any = null;
     private last_trigger: number = 0;
 
+    /** Output of `Main.pushModal`; Input to `Main.popModal()` */
+    private grab_handle: any = null
+
     activate_id: (index: number) => void = () => {}
     cancel: () => void = () => {}
     complete: () => void = () => {}
@@ -243,6 +246,16 @@ export class Search {
     }
 
     close() {
+        try {
+            if (this.grab_handle !== null) {
+                imports.ui.main.popModal(this.grab_handle)
+                this.grab_handle = null
+
+            }
+        } catch (error) {
+            global.logError(error)
+        }
+
         this.reset()
         this.remove_injections()
 
@@ -252,6 +265,7 @@ export class Search {
     }
 
     _open(timestamp: number, on_primary: boolean) {
+        this.grab_handle = imports.ui.main.pushModal(this.dialog.dialogLayout)
         this.dialog.open(timestamp, on_primary)
 
         wm.allowKeybinding('overlay-key', Shell.ActionMode.ALL)

--- a/src/stack.ts
+++ b/src/stack.ts
@@ -418,6 +418,9 @@ export class Stack {
         for (const c of this.tabs) {
             if (Ecs.entity_eq(c.entity, entity)) {
                 this.remove_tab_component(c, idx)
+                if (this.active_id > idx) {
+                    this.active_id -= 1
+                }
                 return idx;
             }
             idx += 1;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -88,7 +88,7 @@ export function is_dark(color: string): boolean {
 }
 
 /** Utility function for running a process in the background and fetching its standard output as a string. */
-export function async_process(argv: Array<string>, input = null, cancellable = null): Promise<string> {
+export function async_process(argv: Array<string>, input = null, cancellable: null | any = null): Promise<string> {
     let flags = Gio.SubprocessFlags.STDOUT_PIPE
 
     if (input !== null)
@@ -96,6 +96,13 @@ export function async_process(argv: Array<string>, input = null, cancellable = n
 
     let proc = new Gio.Subprocess({ argv, flags });
     proc.init(cancellable);
+
+    proc.wait_async(null, (source: any, res: any) => {
+        source.wait_finish(res)
+        if (cancellable !== null) {
+            cancellable.cancel()
+        }
+    })
 
     return new Promise((resolve, reject) => {
         proc.communicate_utf8_async(input, cancellable, (proc: any, res: any) => {

--- a/src/window.ts
+++ b/src/window.ts
@@ -618,7 +618,12 @@ export function activate(ext: Ext, move_mouse: boolean, default_pointer_position
     workspace.activate_with_focus(win, global.get_current_time())
     win.raise()
 
-    if (ext.settings.mouse_cursor_follows_active_window() && move_mouse && !pointer_already_on_window(win)) {
+    const pointer_placement_permitted = move_mouse
+        && imports.ui.main.modalCount === 0
+        && ext.settings.mouse_cursor_follows_active_window()
+        && !pointer_already_on_window(win)
+
+    if (pointer_placement_permitted) {
         place_pointer_on(default_pointer_position, win)
     }
 }

--- a/src/window.ts
+++ b/src/window.ts
@@ -450,6 +450,10 @@ export class ShellWindow {
         return false;
     }
 
+    same_monitor() {
+        return this.meta.get_monitor() === global.display.get_current_monitor()
+    }
+
     /**
      * Sort the window group/always top group with each window border
      * @param updateState NORMAL, RAISED, WORKSPACE_CHANGED

--- a/src/window.ts
+++ b/src/window.ts
@@ -427,14 +427,14 @@ export class ShellWindow {
                     // Ensure that the border is shown
                     if (ACTIVE_HINT_SHOW_ID !== null) GLib.source_remove(ACTIVE_HINT_SHOW_ID)
                     ACTIVE_HINT_SHOW_ID = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 600, () => {
-                        if (border.visible) {
-                            GLib.source_remove(ACTIVE_HINT_SHOW_ID)
+                        if (!this.same_workspace() || border.visible) {
                             ACTIVE_HINT_SHOW_ID = null
-                            return false
+                            return GLib.SOURCE_REMOVE
                         }
 
                         border.show()
-                        return true
+
+                        return GLib.SOURCE_CONTINUE
                     })
                 }
             }

--- a/src/window.ts
+++ b/src/window.ts
@@ -342,7 +342,7 @@ export class ShellWindow {
             if (on_complete) ext.register_fn(on_complete);
             if (meta.appears_focused) {
                 this.update_border_layout();
-                this.show_border();
+                ext.show_border_on_focused();
             }
         }
     }
@@ -592,12 +592,12 @@ export class ShellWindow {
 
     private window_changed() {
         this.update_border_layout();
-        this.show_border();
+        this.ext.show_border_on_focused();
     }
 
     private window_raised() {
         this.restack(RESTACK_STATE.RAISED);
-        this.show_border();
+        this.ext.show_border_on_focused();
     }
 
     private workspace_changed() {


### PR DESCRIPTION
- Closing a window in a stack will
   - no longer jump ahead an extra tab position
   - will activate the previously-focused window
   - focus will remain in stack even if prev window was not stacked
- Closing a non-stacked window will continue to focus the previously-focused window
- Focus will no longer be lost when clicking on the desktop behind a tiled window, which will also fix the occasional loss of focus when navigating with the keyboard
- This should stop the pointer from being placed when in the workspaces/overview mode, or when any modal shell dialog is active
- Fixes possible causes of multiple windows having an active hint at the same time
- Removes an error log for launcher close that isn't an error
- Fixes inability to focus empty display, preventing applications from opening on the empty display

Closes #1412
Closes #1415
Closes #1421
Closes #1422
Closes #1424
Closes #1429