### PR TITLE
Feature: Maintain maximized windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ debian/*
 !debian/*install
 .confirm_shortcut_change
 .vscode
+node_modules


### PR DESCRIPTION
This PR provides a "solution" to [this issue](https://github.com/pop-os/shell/issues/1458). Specifically, it introduces a new option, in the extension settings, which when enabled maximized windows are maintained on focus change events.

For my workflow this feature is really useful. If you find it useful as well, I am more than happy to perform any requested changes.

Cheers