### PR TITLE
fix: update workareas only after screen unlock

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2333,6 +2333,14 @@ export class Ext extends Ecs.System<ExtEvent> {
             return
         }
 
+        if (workareas_only) {
+            if (this.workareas_update !== null) {
+                GLib.source_remove(this.workareas_update)
+                this.workareas_update = null
+            }
+            return;
+        }
+
         // Update every tree on each display with the new dimensions
         const update_tiling = () => {
             if (!this.auto_tiler) return


### PR DESCRIPTION
This PR offers a solution to [this issue](https://github.com/pop-os/shell/issues/1467).