### PR TITLE
fix:  Zoom sometimes opens in tiling mode despite system exception #1442

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -54,7 +54,8 @@ export const DEFAULT_FLOAT_RULES: Array<FloatRule> = [
     { class: "re.sonny.Junction" },
     { class: "system76-driver" },
     { class: "tilda" },
-    { class: "zoom" }
+    { class: "zoom" },
+    { class: "^.*action=join.*$"}
 
 ];
 


### PR DESCRIPTION
Closes #1442 by adding another default floating window exception