### PR TITLE
feat: Ignore accidental window movements/grab ops

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -127,6 +127,9 @@ export class Ext extends Ecs.System<ExtEvent> {
 
     drag_signal: null | SignalID = null
 
+    /** Minimum amount of time for a window to be dragged to apply updates */
+    min_drag_ms: number = 100;
+
     /** If set, the user is currently selecting a window to add to floating exceptions */
     exception_selecting: boolean = false;
 
@@ -147,6 +150,9 @@ export class Ext extends Ecs.System<ExtEvent> {
 
     /** Information about a current possible grab operation */
     grab_op: GrabOp.GrabOp | null = null;
+
+    /** Timestamp of most recent window grab by mouse */
+    private grab_time: number = 0;
 
     /** A display config update is triggered on a workspace addition */
     ignore_display_update: boolean = false;
@@ -1065,6 +1071,11 @@ export class Ext extends Ecs.System<ExtEvent> {
             return;
         }
 
+        // Prevent accidental mouse drag
+        if ((+new Date()) - this.grab_time < this.min_drag_ms) {
+            op = undefined;  // reflow without updating tree
+        }
+
         this.on_grab_end_(win, op);
         this.unset_grab_op()
     }
@@ -1396,6 +1407,7 @@ export class Ext extends Ecs.System<ExtEvent> {
     /** Triggered when a grab operation has been started */
     on_grab_start(meta: null | Meta.Window, op: any) {
         if (!meta) return
+        this.grab_time = +new Date();  // timestamp
         let win = this.get_window(meta);
         if (win) {
             win.grab = true;


### PR DESCRIPTION
## Problem

*Also mentioned in: #1287*

A common **problem** I have is messing up my window tree by accidentally grabbing the titlebar of a window or by [holding the super key](https://wiki.gnome.org/Gnome3CheatSheet#Resizing_Windows) and accidentally clicking anywhere on the window, dragging it. These accidental grabs/movements/re-positions of the window cause an instant reflow of the tree that can be disorienting and distracting focus from your main task.

https://user-images.githubusercontent.com/4530010/174450402-b7be9b72-35d0-4824-a7b3-fcea9bb9cabb.mp4

* * *

## Solution

My preferred **solution** is to allow a small duration of time for the extension to ignore a window grab op/movement.

When we start a grab op, we set a current timestamp in the new `grab_time` property. When the grab op ends, that stored value is subtracted from the new current timestamp. If the result in milliseconds is less than the specified `min_drag_ms` then the `op` is set to `null` so the tree reflows back into position without being changed, essentially ignoring the window grab op/movement.

I don't know about you, but I know I'm not making precise window movement decisions in under 100ms. 100ms has worked so far for me and it could probably be as high as 200ms. I think 100ms is a good duration of buffer time for the autotiler to ignore an accident.

https://user-images.githubusercontent.com/4530010/174450413-3caded1a-5512-4459-a9c6-642cf896e2a4.mp4

* * *

### Another lesser solution (not implemented)

Another solution is to compare the before and after window positions and determine if it has moved a far enough distance to warrant a tree change. This method would require a lot more logic. I consider this solution to be inferior to the paragraph above as High DPI mice/high resolution monitors would thwart this measure and we'd probably have to use percentages instead of pixels.

--

*Work still in-progress?* I haven't thoroughly tested this on any machine other than my own with GNOME 42.1. I'm very open to conversation and suggestions on the mechanics of this thing.