### PR TITLE
Add firefox exception except main window

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -42,6 +42,7 @@ export const DEFAULT_FLOAT_RULES: Array<FloatRule> = [
     { class: "Steam", title: "^.*(Guard|Login).*" },
     { class: "TelegramDesktop", title: "Media viewer" },
     { class: "Zotero", title: "Quick Format Citation" },
+    { class: "firefox", title: "^(?!.*Mozilla Firefox).*$" },
     { class: "gjs" },
     { class: "gnome-screenshot" },
     { class: "ibus-.*" },


### PR DESCRIPTION
It is convenient to have non-main window in floating mode.

It fixes #756 and maybe other issues.