### PR TITLE
feat: global tiling

### DIFF
--- a/keybindings/10-pop-shell-move.xml
+++ b/keybindings/10-pop-shell-move.xml
@@ -6,6 +6,10 @@
   <KeyListEntry name="tile-move-left" description="Move window left"/>
   <KeyListEntry name="tile-move-right" description="Move window right"/>
   <KeyListEntry name="tile-move-up" description="Move window up"/>
+  <KeyListEntry name="tile-move-down-global" description="Move window down outside management mode"/>
+  <KeyListEntry name="tile-move-left-global" description="Move window left outside management mode"/>
+  <KeyListEntry name="tile-move-right-global" description="Move window right outside management mode"/>
+  <KeyListEntry name="tile-move-up-global" description="Move window up outside management mode"/>
   <KeyListEntry name="pop-workspace-down" description="Move window to lower workspace"/>
   <KeyListEntry name="pop-workspace-up" description="Move window to upper workspace"/>
   <KeyListEntry name="pop-monitor-down" description="Move window to lower monitor"/>

--- a/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
@@ -153,6 +153,26 @@
             <summary>Move window right</summary>
         </key>
 
+        <key type="as" name="tile-move-left-global">
+            <default><![CDATA[[]]]></default>
+            <summary>Move window left</summary>
+        </key>
+
+        <key type="as" name="tile-move-down-global">
+            <default><![CDATA[[]]]></default>
+            <summary>Move window down</summary>
+        </key>
+
+        <key type="as" name="tile-move-up-global">
+            <default><![CDATA[[]]]></default>
+            <summary>Move window up</summary>
+        </key>
+
+        <key type="as" name="tile-move-right-global">
+            <default><![CDATA[[]]]></default>
+            <summary>Move window right</summary>
+        </key>
+
         <key type="as" name="tile-orientation">
             <default><![CDATA[['<Super>o']]]></default>
             <summary>Toggle tiling orientation</summary>

--- a/src/keybindings.ts
+++ b/src/keybindings.ts
@@ -42,6 +42,14 @@ export class Keybindings {
 
             "toggle-stacking-global": () => ext.auto_tiler?.toggle_stacking(ext),
 
+            "tile-move-left-global": () => ext.tiler.move_left(ext, ext.focus_window()?.entity),
+
+            "tile-move-down-global": () => ext.tiler.move_down(ext, ext.focus_window()?.entity),
+
+            "tile-move-up-global": () => ext.tiler.move_up(ext, ext.focus_window()?.entity),
+
+            "tile-move-right-global": () => ext.tiler.move_right(ext, ext.focus_window()?.entity),
+
             "pop-monitor-left": () => ext.move_monitor(Meta.DisplayDirection.LEFT),
 
             "pop-monitor-right": () => ext.move_monitor(Meta.DisplayDirection.RIGHT),

--- a/src/tiling.ts
+++ b/src/tiling.ts
@@ -187,9 +187,9 @@ export class Tiler {
         return new_fork[1];
     }
 
-    move(ext: Ext, x: number, y: number, w: number, h: number, direction: Direction, focus: () => window.ShellWindow | number | null) {
-        if (!this.window) return;
-        const win = ext.windows.get(this.window)
+    move(ext: Ext, window: Entity | null, x: number, y: number, w: number, h: number, direction: Direction, focus: () => window.ShellWindow | number | null) {
+        if (!window) return
+        const win = ext.windows.get(window);
         if (!win) return
 
         const place_pointer = () => {
@@ -575,32 +575,32 @@ export class Tiler {
         }
     }
 
-    move_left(ext: Ext) {
-        this.move(ext, -1, 0, 0, 0, Direction.Left, move_window_or_monitor(
+    move_left(ext: Ext, window?: Entity) {
+        this.move(ext, window ?? this.window, -1, 0, 0, 0, Direction.Left, move_window_or_monitor(
             ext,
             ext.focus_selector.left,
             Meta.DisplayDirection.LEFT
         ));
     }
 
-    move_down(ext: Ext) {
-        this.move(ext, 0, 1, 0, 0, Direction.Down, move_window_or_monitor(
+    move_down(ext: Ext, window?: Entity) {
+        this.move(ext, window ?? this.window, 0, 1, 0, 0, Direction.Down, move_window_or_monitor(
             ext,
             ext.focus_selector.down,
             Meta.DisplayDirection.DOWN
         ));
     }
-
-    move_up(ext: Ext) {
-        this.move(ext, 0, -1, 0, 0, Direction.Up, move_window_or_monitor(
+ 
+    move_up(ext: Ext, window?: Entity) {
+        this.move(ext, window ?? this.window, 0, -1, 0, 0, Direction.Up, move_window_or_monitor(
             ext,
             ext.focus_selector.up,
             Meta.DisplayDirection.UP
         ));
     }
 
-    move_right(ext: Ext) {
-        this.move(ext, 1, 0, 0, 0, Direction.Right, move_window_or_monitor(
+    move_right(ext: Ext, window?: Entity) {
+        this.move(ext, window ?? this.window, 1, 0, 0, 0, Direction.Right, move_window_or_monitor(
             ext,
             ext.focus_selector.right,
             Meta.DisplayDirection.RIGHT


### PR DESCRIPTION
A (somewhat) hacky solution for #1400.
Introducing 4 new dconf names:
- tile-move-down-global
- tile-move-left-global
- tile-move-right-global
- tile-move-up-global

which are per-default empty.
These functions are for moving tiles outside of the management mode for a (optional) more i3-like experience.

For implementing this feature, I hijacked `move`, `move_up`,  `move_left`, `move_right`, `move_down` and requested that an additional argument (the moved window) is passed. By doing this, a calling function can either specify `this.window` if its called from within the management mode or `ext.focus_window()?.entity` if its called from a global state.

I feel like because of this additional window-entity parameter, all of the move functions should be refactored into the AutoTiler. then the tiler could use the AutoTiler for moving windows (like its currently done with the `toggle_stacking`-function)