### PR TITLE
feat: active-hint-border-radius

### DIFF
--- a/dark.css
+++ b/dark.css
@@ -1,7 +1,7 @@
 .pop-shell-active-hint {
     border-style: solid;
     border-color: #FBB86C;
-    border-radius: 5px;
+    border-radius: var(--active-hint-border-radius, 5px);
     box-shadow: inset 0 0 0 1px rgba(24, 23, 23, 0)
 }
 

--- a/highcontrast.css
+++ b/highcontrast.css
@@ -1,7 +1,7 @@
 .pop-shell-active-hint {
     border-style: solid;
     border-color: #FBB86C;
-    border-radius: 5px;
+    border-radius: var(--active-hint-border-radius, 5px);
     box-shadow: inset 0 0 0 1px rgba(24, 23, 23, 0)
 }
 

--- a/light.css
+++ b/light.css
@@ -1,7 +1,7 @@
 .pop-shell-active-hint {
     border-style: solid;
     border-color: #FFAD00;
-    border-radius: 5px;
+    border-radius: var(--active-hint-border-radius, 5px);
     box-shadow: inset 0 0 0 1px rgba(200, 200, 200, 0);
 }
 

--- a/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
@@ -9,6 +9,7 @@
 
         <key type="u" name="active-hint-border-radius">
             <default>5</default>
+            <range min="5" max="30"/>
             <summary>Border radius for active window hint, in pixels</summary>
         </key>
 

--- a/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
@@ -7,6 +7,11 @@
             <summary>Show a hint around the active window</summary>
         </key>
 
+        <key type="u" name="active-hint-border-radius">
+            <default>5</default>
+            <summary>Border radius for active window hint, in pixels</summary>
+        </key>
+
         <key type="b" name="fullscreen-launcher">
             <default>false</default>
             <summary>Allow showing launcher above fullscreen windows</summary>

--- a/src/panel_settings.ts
+++ b/src/panel_settings.ts
@@ -16,6 +16,7 @@ export class Indicator {
     toggle_tiled : any
     toggle_titles: null | any
     toggle_active: any
+    border_radius: any
 
     entry_gaps: any
 
@@ -64,6 +65,14 @@ export class Indicator {
             }
         )
 
+        this.border_radius = number_entry(
+            _("Active Border Radius"),
+            ext.settings.active_hint_border_radius(),
+            (value) => {
+                ext.settings.set_active_hint_border_radius(value);
+            }
+        )
+
         bm.addMenuItem(this.toggle_tiled);
         bm.addMenuItem(floating_window_exceptions(ext, bm));
 
@@ -78,6 +87,7 @@ export class Indicator {
         }
 
         bm.addMenuItem(this.toggle_active);
+        bm.addMenuItem(this.border_radius);
 
         // CSS Selector
         bm.addMenuItem(color_selector(ext, bm),);

--- a/src/panel_settings.ts
+++ b/src/panel_settings.ts
@@ -67,7 +67,11 @@ export class Indicator {
 
         this.border_radius = number_entry(
             _("Active Border Radius"),
-            ext.settings.active_hint_border_radius(),
+            {
+              value: ext.settings.active_hint_border_radius(),
+              min: 5,
+              max: 30
+            },
             (value) => {
                 ext.settings.set_active_hint_border_radius(value);
             }
@@ -203,15 +207,19 @@ function shortcuts(menu: any): any {
     return item;
 }
 
-function clamp(input: number): number {
-    return Math.min(Math.max(0, input), 128);
+function clamp(input: number, min = 0, max = 128): number {
+    return Math.min(Math.max(min, input), max);
 }
 
 function number_entry(
     label: string,
-    value: number,
+    valueOrOptions: number|{value: number, min: number, max: number},
     callback: (a: number) => void,
 ): any {
+    let value = valueOrOptions, min: number, max: number;
+    if (typeof valueOrOptions !== 'number')
+      ({ value, min, max } = valueOrOptions);
+
     const entry = new St.Entry({
         text: String(value),
         input_purpose: Clutter.InputContentPurpose.NUMBER,
@@ -234,9 +242,9 @@ function number_entry(
             symbol == 65293     // enter key
                 ? parse_number(text.text)
                 : symbol == 65361   // left key
-                    ? clamp(parse_number(text.text) - 1)
+                    ? clamp(parse_number(text.text) - 1, min, max)
                     : symbol == 65363   // right key
-                        ? clamp(parse_number(text.text) + 1)
+                        ? clamp(parse_number(text.text) + 1, min, max)
                         : null;
 
         if (number !== null) {
@@ -250,12 +258,12 @@ function number_entry(
 
     entry.set_primary_icon(create_icon('value-decrease'))
     entry.connect('primary-icon-clicked', () => {
-        text.set_text(String(clamp(parseInt(text.get_text()) - 1)))
+        text.set_text(String(clamp(parseInt(text.get_text()) - 1, min, max)))
     })
 
     entry.set_secondary_icon(create_icon('value-increase'))
     entry.connect('secondary-icon-clicked', () => {
-        text.set_text(String(clamp(parseInt(text.get_text()) + 1)))
+        text.set_text(String(clamp(parseInt(text.get_text()) + 1, min, max)))
     })
 
     text.connect('text-changed', () => {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -48,6 +48,7 @@ function settings_new_schema(schema: string): Settings {
 }
 
 const ACTIVE_HINT = "active-hint";
+const ACTIVE_HINT_BORDER_RADIUS = "active-hint-border-radius";
 const COLUMN_SIZE = "column-size";
 const EDGE_TILING = "edge-tiling";
 const FULLSCREEN_LAUNCHER = "fullscreen-launcher"
@@ -74,6 +75,10 @@ export class ExtensionSettings {
 
     active_hint(): boolean {
         return this.ext.get_boolean(ACTIVE_HINT);
+    }
+
+    active_hint_border_radius(): number {
+        return this.ext.get_uint(ACTIVE_HINT_BORDER_RADIUS);
     }
 
     column_size(): number {
@@ -166,6 +171,10 @@ export class ExtensionSettings {
 
     set_active_hint(set: boolean) {
         this.ext.set_boolean(ACTIVE_HINT, set);
+    }
+
+    set_active_hint_border_radius(set: number) {
+        this.ext.set_uint(ACTIVE_HINT_BORDER_RADIUS, set);
     }
 
     set_column_size(size: number) {

--- a/src/window.ts
+++ b/src/window.ts
@@ -189,8 +189,7 @@ export class ShellWindow {
             this.ext.overlay.set_style(`background: ${gdk.to_string()}`);
         }
 
-        if (this.border)
-            this.border.set_style(`border-color: ${color_value}`);
+        this.update_border_style()
     }
 
     cmdline(): string | null {
@@ -418,6 +417,7 @@ export class ShellWindow {
         if (!this.border) return
 
         this.restack();
+        this.update_border_style();
         if (this.ext.settings.active_hint()) {
             let border = this.border;
 
@@ -624,6 +624,15 @@ export class ShellWindow {
                 border.set_position(x, y)
                 border.set_size(width, height)
             }
+        }
+    }
+
+    update_border_style() {
+        const { settings } = this.ext
+        const color_value = settings.hint_color_rgba();
+        const radius_value = settings.active_hint_border_radius();
+        if (this.border) {
+            this.border.set_style(`border-color: ${color_value}; border-radius: ${radius_value}px;`);
         }
     }
 


### PR DESCRIPTION
## Why?
Better integration with stock GNOME (Fedora, in this case)

## What?
Adds an `active-hint-border-radius` configuration setting to the database and to the panel UI

![Screenshot from 2022-08-18 14-47-08](https://user-images.githubusercontent.com/1466420/185387537-ca181eff-a1f7-405c-9459-4bdb8d076fce.png)

## Notes

This is my first GTK/GNOME rodeo. Pop shell is :man_cook: :kiss:  though, great work!

Reviewers, please take a look at the settings schema and code, as I was not yet able to view the setting with description in dconf-editor

![Screenshot from 2022-08-18 14-49-44](https://user-images.githubusercontent.com/1466420/185387770-327c39b9-ddbd-4bad-a22d-553714eb747c.png)
