### PR TITLE
active border radius minimum zero

### DIFF
--- a/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
@@ -9,7 +9,7 @@
 
         <key type="u" name="active-hint-border-radius">
             <default>5</default>
-            <range min="5" max="30"/>
+            <range min="0" max="30"/>
             <summary>Border radius for active window hint, in pixels</summary>
         </key>
 

--- a/src/panel_settings.ts
+++ b/src/panel_settings.ts
@@ -69,7 +69,7 @@ export class Indicator {
             _("Active Border Radius"),
             {
               value: ext.settings.active_hint_border_radius(),
-              min: 5,
+              min: 0,
               max: 30
             },
             (value) => {


### PR DESCRIPTION
This changes the lower bound for the Active Border Radius to zero per user request https://github.com/pop-os/shell/issues/1522. This does not change the default value.