### PR TITLE
feat: Move mouse focus position config to gnome extension options

### DIFF
--- a/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
@@ -43,6 +43,11 @@
             <summary>Move cursor to active window when navigating with keyboard shortcuts or touchpad gestures</summary>
         </key>
 
+        <key type="u" name="mouse-focus-location">
+            <default>0</default>
+            <summary>The location the mouse cursor focuses when selecting a window</summary>
+        </key>
+
         <!-- Tiling Options -->
         <key type="u" name="column-size">
             <default>64</default>

--- a/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
@@ -43,7 +43,7 @@
             <summary>Move cursor to active window when navigating with keyboard shortcuts or touchpad gestures</summary>
         </key>
 
-        <key type="u" name="mouse-focus-location">
+        <key type="u" name="mouse-cursor-focus-position">
             <default>0</default>
             <summary>The location the mouse cursor focuses when selecting a window</summary>
         </key>

--- a/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
@@ -43,7 +43,7 @@
             <summary>Move cursor to active window when navigating with keyboard shortcuts or touchpad gestures</summary>
         </key>
 
-        <key type="u" name="mouse-cursor-focus-position">
+        <key type="u" name="mouse-cursor-focus-location">
             <default>0</default>
             <summary>The location the mouse cursor focuses when selecting a window</summary>
         </key>

--- a/src/config.ts
+++ b/src/config.ts
@@ -83,14 +83,6 @@ export interface FloatRule {
     title?: string;
 };
 
-export enum DefaultPointerPosition {
-    TopLeft = "Top Left",
-    TopRight = "Top Right",
-    BottomLeft = "Bottom Left",
-    BottomRight = "Bottom Right",
-    Center = "Center",
-};
-
 export class Config {
     /** List of windows that should float, regardless of their WM hints */
     float: Array<FloatRule> = [];

--- a/src/config.ts
+++ b/src/config.ts
@@ -84,11 +84,11 @@ export interface FloatRule {
 };
 
 export enum DefaultPointerPosition {
-    TopLeft = "TOP_LEFT",
-    TopRight = "TOP_RIGHT",
-    BottomLeft = "BOTTOM_LEFT",
-    BottomRight = "BOTTOM_RIGHT",
-    Center = "CENTER",
+    TopLeft = "Top Left",
+    TopRight = "Top Right",
+    BottomLeft = "Bottom Left",
+    BottomRight = "Bottom Right",
+    Center = "Center",
 };
 
 export class Config {
@@ -103,9 +103,6 @@ export class Config {
 
     /** Logs window details on focus of window */
     log_on_focus: boolean = false;
-
-    /** Specify default pointer position when you're switching windows */
-    default_pointer_position: DefaultPointerPosition = DefaultPointerPosition.TopLeft;
 
     /** Add a floating exception which matches by wm_class */
     add_app_exception(wmclass: string) {
@@ -179,7 +176,6 @@ export class Config {
             let c = conf.value;
             this.float = c.float;
             this.log_on_focus = c.log_on_focus;
-            this.default_pointer_position = c.default_pointer_position;
         } else {
             log(`error loading conf: ${conf.why}`)
         }

--- a/src/focus.ts
+++ b/src/focus.ts
@@ -6,6 +6,14 @@ import * as Geom from 'geom';
 import type { ShellWindow } from 'window';
 import type { Ext } from './extension';
 
+export enum FocusPosition {
+    TopLeft = "Top Left",
+    TopRight = "Top Right",
+    BottomLeft = "Bottom Left",
+    BottomRight = "Bottom Right",
+    Center = "Center",
+}
+
 export class FocusSelector {
     select(
         ext: Ext,

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -160,8 +160,20 @@ function settings_dialog_view(): [AppWidgets, Gtk.Container] {
     grid.attach(mouse_cursor_follows_active_window_label, 0, 5, 1, 1)
     grid.attach(settings.mouse_cursor_follows_active_window, 1, 5, 1, 1)
 
-    build_combo(grid, 6, config.DefaultPointerPosition, 'Mouse Focus Location', 'mouse-focus-location')
-    build_combo(grid, 7, log.LOG_LEVELS, 'Log Level', 'log-level')
+    build_combo(
+        grid,
+        6,
+        config.DefaultPointerPosition,
+        'Mouse Cursor Focus Position',
+        'mouse-cursor-focus-position',
+    )
+    build_combo(
+        grid,
+        7,
+        log.LOG_LEVELS,
+        'Log Level',
+        'log-level',
+    )
 
     return [settings, grid]
 }

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -10,7 +10,7 @@ const { Settings } = imports.gi.Gio;
 
 import * as settings from 'settings';
 import * as log from 'log';
-import * as config from 'config';
+import * as focus from 'focus';
 
 interface AppWidgets {
     fullscreen_launcher: any,
@@ -163,7 +163,7 @@ function settings_dialog_view(): [AppWidgets, Gtk.Container] {
     build_combo(
         grid,
         6,
-        config.DefaultPointerPosition,
+        focus.FocusPosition,
         'Mouse Cursor Focus Position',
         'mouse-cursor-focus-position',
     )

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -64,6 +64,7 @@ const DEFAULT_RGBA_COLOR = "rgba(251, 184, 108, 1)"; //pop-orange
 const LOG_LEVEL = "log-level";
 const SHOW_SKIPTASKBAR = "show-skip-taskbar";
 const MOUSE_CURSOR_FOLLOWS_ACTIVE_WINDOW = "mouse-cursor-follows-active-window"
+const MOUSE_FOCUS_LOCATION = "mouse-focus-location";
 
 export class ExtensionSettings {
     ext: Settings = settings_new_schema(Me.metadata["settings-schema"]);
@@ -167,6 +168,10 @@ export class ExtensionSettings {
         return this.ext.get_boolean(MOUSE_CURSOR_FOLLOWS_ACTIVE_WINDOW);
     }
 
+    mouse_focus_location(): number {
+        return this.ext.get_uint(MOUSE_FOCUS_LOCATION);
+    }
+
     // Setters
 
     set_active_hint(set: boolean) {
@@ -237,5 +242,9 @@ export class ExtensionSettings {
 
     set_mouse_cursor_follows_active_window(set: boolean) {
         this.ext.set_boolean(MOUSE_CURSOR_FOLLOWS_ACTIVE_WINDOW, set);
+    }
+
+    set_mouse_focus_location(set: number) {
+        this.ext.set_uint(MOUSE_FOCUS_LOCATION, set);
     }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -64,7 +64,7 @@ const DEFAULT_RGBA_COLOR = "rgba(251, 184, 108, 1)"; //pop-orange
 const LOG_LEVEL = "log-level";
 const SHOW_SKIPTASKBAR = "show-skip-taskbar";
 const MOUSE_CURSOR_FOLLOWS_ACTIVE_WINDOW = "mouse-cursor-follows-active-window"
-const MOUSE_FOCUS_LOCATION = "mouse-focus-location";
+const MOUSE_FOCUS_LOCATION = "mouse-cursor-focus-position";
 
 export class ExtensionSettings {
     ext: Settings = settings_new_schema(Me.metadata["settings-schema"]);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -64,7 +64,7 @@ const DEFAULT_RGBA_COLOR = "rgba(251, 184, 108, 1)"; //pop-orange
 const LOG_LEVEL = "log-level";
 const SHOW_SKIPTASKBAR = "show-skip-taskbar";
 const MOUSE_CURSOR_FOLLOWS_ACTIVE_WINDOW = "mouse-cursor-follows-active-window"
-const MOUSE_FOCUS_LOCATION = "mouse-cursor-focus-position";
+const MOUSE_CURSOR_FOCUS_LOCATION = "mouse-cursor-focus-location";
 
 export class ExtensionSettings {
     ext: Settings = settings_new_schema(Me.metadata["settings-schema"]);
@@ -168,8 +168,8 @@ export class ExtensionSettings {
         return this.ext.get_boolean(MOUSE_CURSOR_FOLLOWS_ACTIVE_WINDOW);
     }
 
-    mouse_focus_location(): number {
-        return this.ext.get_uint(MOUSE_FOCUS_LOCATION);
+    mouse_cursor_focus_location(): number {
+        return this.ext.get_uint(MOUSE_CURSOR_FOCUS_LOCATION);
     }
 
     // Setters
@@ -244,7 +244,7 @@ export class ExtensionSettings {
         this.ext.set_boolean(MOUSE_CURSOR_FOLLOWS_ACTIVE_WINDOW, set);
     }
 
-    set_mouse_focus_location(set: number) {
-        this.ext.set_uint(MOUSE_FOCUS_LOCATION, set);
+    set_mouse_cursor_focus_location(set: number) {
+        this.ext.set_uint(MOUSE_CURSOR_FOCUS_LOCATION, set);
     }
 }

--- a/src/window.ts
+++ b/src/window.ts
@@ -379,8 +379,7 @@ export class ShellWindow {
         let br = other.rect().clone();
 
         other.move(ext, ar);
-        this.move(ext, br, () => place_pointer_on(
-            this.ext.settings.mouse_cursor_focus_location(), this.meta)
+        this.move(ext, br, () => place_pointer_on(this.ext, this.meta)
         );
     }
 
@@ -682,7 +681,7 @@ export function activate(ext: Ext, move_mouse: boolean, win: Meta.Window) {
             && pointer_in_work_area()
 
         if (pointer_placement_permitted) {
-            place_pointer_on(ext.settings.mouse_cursor_focus_location(), win)
+            place_pointer_on(ext, win)
         }
     } catch (error) {
         log.error(`failed to activate window: ${error}`)
@@ -699,14 +698,13 @@ function pointer_in_work_area(): boolean {
     return mon ? cursor.intersects(mon) : false
 }
 
-export function place_pointer_on(pointer_position: number, win: Meta.Window) {
+export function place_pointer_on(ext: Ext, win: Meta.Window) {
     const rect = win.get_frame_rect();
     let x = rect.x;
     let y = rect.y;
 
-    let pointer_position_ = focus.FocusPosition[
-        Object.keys(focus.FocusPosition)[pointer_position] as keyof typeof focus.FocusPosition
-    ]
+    let key = Object.keys(focus.FocusPosition)[ext.settings.mouse_cursor_focus_location()]
+    let pointer_position_ = focus.FocusPosition[key as keyof typeof focus.FocusPosition]
 
     switch (pointer_position_) {
         case focus.FocusPosition.TopLeft:

--- a/src/window.ts
+++ b/src/window.ts
@@ -1,7 +1,6 @@
 // @ts-ignore
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 
-import * as Config from 'config';
 import * as lib from 'lib';
 import * as log from 'log';
 import * as once_cell from 'once_cell';
@@ -13,8 +12,8 @@ import type { Entity } from './ecs';
 import type { Ext } from './extension';
 import type { Rectangle } from './rectangle';
 import * as scheduler from 'scheduler';
+import * as focus from 'focus';
 
-const { DefaultPointerPosition } = Config;
 const { Gdk, Meta, Shell, St, GLib } = imports.gi;
 
 const { OnceCell } = once_cell;
@@ -703,28 +702,28 @@ export function place_pointer_on(pointer_position: number, win: Meta.Window) {
     let x = rect.x;
     let y = rect.y;
 
-    let pointer_position_ = DefaultPointerPosition[
-        Object.keys(DefaultPointerPosition)[pointer_position] as keyof typeof DefaultPointerPosition
+    let pointer_position_ = focus.FocusPosition[
+        Object.keys(focus.FocusPosition)[pointer_position] as keyof typeof focus.FocusPosition
     ]
 
     switch (pointer_position_) {
-        case DefaultPointerPosition.TopLeft:
+        case focus.FocusPosition.TopLeft:
             x += 8;
             y += 8;
             break;
-        case DefaultPointerPosition.BottomLeft:
+        case focus.FocusPosition.BottomLeft:
             x += 8;
             y += (rect.height - 16);
             break;
-        case DefaultPointerPosition.TopRight:
+        case focus.FocusPosition.TopRight:
             x += (rect.width - 16);
             y += 8;
             break;
-        case DefaultPointerPosition.BottomRight:
+        case focus.FocusPosition.BottomRight:
             x += (rect.width - 16);
             y += (rect.height - 16);
             break;
-        case DefaultPointerPosition.Center:
+        case focus.FocusPosition.Center:
             x += (rect.width / 2) + 8;
             y += (rect.height / 2) + 8;
             break;

--- a/src/window.ts
+++ b/src/window.ts
@@ -123,7 +123,7 @@ export class ShellWindow {
     }
 
     activate(move_mouse: boolean = true): void {
-        activate(this.ext, move_mouse, this.ext.settings.mouse_focus_location(), this.meta);
+        activate(this.ext, move_mouse, this.meta);
     }
 
     actor_exists(): boolean {
@@ -379,7 +379,9 @@ export class ShellWindow {
         let br = other.rect().clone();
 
         other.move(ext, ar);
-        this.move(ext, br, () => place_pointer_on(this.ext.settings.mouse_focus_location(), this.meta));
+        this.move(ext, br, () => place_pointer_on(
+            this.ext.settings.mouse_cursor_focus_location(), this.meta)
+        );
     }
 
     title(): string {
@@ -660,7 +662,7 @@ export class ShellWindow {
 }
 
 /// Activates a window, and moves the mouse point.
-export function activate(ext: Ext, move_mouse: boolean, mouse_focus_location: number, win: Meta.Window) {
+export function activate(ext: Ext, move_mouse: boolean, win: Meta.Window) {
     try {
         if (win.is_override_redirect()) return
 
@@ -680,7 +682,7 @@ export function activate(ext: Ext, move_mouse: boolean, mouse_focus_location: nu
             && pointer_in_work_area()
 
         if (pointer_placement_permitted) {
-            place_pointer_on(mouse_focus_location, win)
+            place_pointer_on(ext.settings.mouse_cursor_focus_location(), win)
         }
     } catch (error) {
         log.error(`failed to activate window: ${error}`)

--- a/src/window.ts
+++ b/src/window.ts
@@ -124,7 +124,7 @@ export class ShellWindow {
     }
 
     activate(move_mouse: boolean = true): void {
-        activate(this.ext, move_mouse, this.ext.conf.default_pointer_position, this.meta);
+        activate(this.ext, move_mouse, this.ext.settings.mouse_focus_location(), this.meta);
     }
 
     actor_exists(): boolean {
@@ -380,7 +380,7 @@ export class ShellWindow {
         let br = other.rect().clone();
 
         other.move(ext, ar);
-        this.move(ext, br, () => place_pointer_on(this.ext.conf.default_pointer_position, this.meta));
+        this.move(ext, br, () => place_pointer_on(this.ext.settings.mouse_focus_location(), this.meta));
     }
 
     title(): string {
@@ -661,7 +661,7 @@ export class ShellWindow {
 }
 
 /// Activates a window, and moves the mouse point.
-export function activate(ext: Ext, move_mouse: boolean, default_pointer_position: Config.DefaultPointerPosition, win: Meta.Window) {
+export function activate(ext: Ext, move_mouse: boolean, mouse_focus_location: number, win: Meta.Window) {
     try {
         if (win.is_override_redirect()) return
 
@@ -681,7 +681,7 @@ export function activate(ext: Ext, move_mouse: boolean, default_pointer_position
             && pointer_in_work_area()
 
         if (pointer_placement_permitted) {
-            place_pointer_on(default_pointer_position, win)
+            place_pointer_on(mouse_focus_location, win)
         }
     } catch (error) {
         log.error(`failed to activate window: ${error}`)
@@ -698,12 +698,16 @@ function pointer_in_work_area(): boolean {
     return mon ? cursor.intersects(mon) : false
 }
 
-export function place_pointer_on(default_pointer_position: Config.DefaultPointerPosition, win: Meta.Window) {
+export function place_pointer_on(pointer_position: number, win: Meta.Window) {
     const rect = win.get_frame_rect();
     let x = rect.x;
     let y = rect.y;
 
-    switch (default_pointer_position) {
+    let pointer_position_ = DefaultPointerPosition[
+        Object.keys(DefaultPointerPosition)[pointer_position] as keyof typeof DefaultPointerPosition
+    ]
+
+    switch (pointer_position_) {
         case DefaultPointerPosition.TopLeft:
             x += 8;
             y += 8;

--- a/src/window.ts
+++ b/src/window.ts
@@ -698,7 +698,7 @@ function pointer_in_work_area(): boolean {
     return mon ? cursor.intersects(mon) : false
 }
 
-export function place_pointer_on(ext: Ext, win: Meta.Window) {
+function place_pointer_on(ext: Ext, win: Meta.Window) {
     const rect = win.get_frame_rect();
     let x = rect.x;
     let y = rect.y;


### PR DESCRIPTION
This PR moves mouse focus config to the extension options. A problem I had when using Pop shell was figuring out how to make the mouse cursor centered when you select a tiled window. This PR fixes that by putting the configuration option in a more visible place.
`DefaultPointerPosition` is renamed to `FocusPosition` and moved to `src/focus.ts` because it does not belong with the config class after this PR.
If a user set a value in the old config file then updates to this version, the config will be reset. I do not know a good way to respect the old config value.

Is it worth considering merging the "Mouse Cursor Follows Active Window" and "Mouse Cursor Focus Position" options?