### PR TITLE
fix: don't raise stacked windows on focus

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -878,7 +878,6 @@ export class Ext extends Ecs.System<ExtEvent> {
 
         // Update the active tab in the stack.
         if (null !== this.auto_tiler && null !== win.stack) {
-            win.meta.raise();
             ext?.auto_tiler?.forest.stacks.get(win.stack)?.activate(win.entity)
         }
 


### PR DESCRIPTION
Fixes #1539. Stacked windows no longer raise when focused, but still raise when activated normally.

Am new to contributing to Pop Shell - let me know if there is some testing needed for this PR.