### PR TITLE
feat: add settings toggle for showing stack tab buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ debian/*
 !debian/*install
 .confirm_shortcut_change
 .vscode
+*.vim
 node_modules

--- a/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
@@ -33,6 +33,11 @@
             <summary>Show title bars on windows with server-side decorations</summary>
         </key>
 
+        <key type="b" name="show-stack-tab-buttons">
+            <default>true</default>
+            <summary>Show tabs for stacked windows</summary>
+        </key>
+
         <key type="b" name="show-skip-taskbar">
             <default>true</default>
             <summary>Handle minimized to tray windows</summary>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1135,7 +1135,7 @@ export class Ext extends Ecs.System<ExtEvent> {
                     const fork = forest.forks.get(fork_entity);
                     if (fork) {
                         if (win.stack) {
-                            const tab_dimension = this.dpi * stack.TAB_HEIGHT;
+                            const tab_dimension = stack.calculate_tabs_height(this);
                             crect.height += tab_dimension;
                             crect.y -= tab_dimension;
                         }
@@ -1892,6 +1892,16 @@ export class Ext extends Ecs.System<ExtEvent> {
                     break;
                 case 'show-title':
                     this.on_show_window_titles();
+                    break;
+                case 'show-stack-tab-buttons':
+                    if (!this.auto_tiler) break;
+                    
+                    for (const [window] of this.auto_tiler.attached.iter()) {
+                        const win = this.windows.get(window)
+                        if (win)
+                            this.on_grab_end_(win);
+                    }
+
                     break;
                 case 'smart-gaps':
                     this.on_smart_gap();

--- a/src/node.ts
+++ b/src/node.ts
@@ -7,7 +7,7 @@ import type { Forest } from './forest';
 import type { Entity } from 'ecs';
 import type { Ext } from 'extension';
 import type { Rectangle } from 'rectangle';
-import type { Stack } from 'stack';
+import * as stack from 'stack';
 import { ShellWindow } from './window';
 
 /** A node is either a fork a window */
@@ -41,7 +41,7 @@ export interface NodeStack {
     rect: Rectangle | null;
 }
 
-function stack_detach(node: NodeStack, stack: Stack, idx: number) {
+function stack_detach(node: NodeStack, stack: stack.Stack, idx: number) {
     node.entities.splice(idx, 1);
     stack.remove_by_pos(idx);
 }
@@ -233,11 +233,11 @@ export class Node {
                 break
             // Stack
             case 3:
-                const size = ext.dpi * 4;
+                const size = stack.calculate_tabs_height(ext);
 
                 this.inner.rect = area.clone();
-                this.inner.rect.y += size * 6;
-                this.inner.rect.height -= size * 6;
+                this.inner.rect.y += size;
+                this.inner.rect.height -= size;
 
                 for (const entity of this.inner.entities) {
                     record(entity, parent, this.inner.rect);

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -21,6 +21,7 @@ interface AppWidgets {
     show_skip_taskbar: any,
     smart_gaps: any,
     snap_to_grid: any,
+    stack_tabs_buttons: any,
     window_titles: any,
     mouse_cursor_focus_position: any,
     log_level: any,
@@ -37,6 +38,12 @@ function settings_dialog_new(): Gtk.Container {
     app.window_titles.set_active(ext.show_title());
     app.window_titles.connect('state-set', (_widget: any, state: boolean) => {
         ext.set_show_title(state);
+        Settings.sync();
+    });
+
+    app.stack_tabs_buttons.set_active(ext.show_stack_tab_buttons());
+    app.stack_tabs_buttons.connect('state-set', (_widget: any, state: boolean) => {
+        ext.set_show_stack_tab_buttons(state);
         Settings.sync();
     });
 
@@ -125,6 +132,11 @@ function settings_dialog_view(): [AppWidgets, Gtk.Container] {
         hexpand: true
     })
 
+    const stack_tab_buttons_label = new Gtk.Label({
+        label: "Show tabs for stacked windows",
+        xalign: 0.0
+    })
+
     const snap_label = new Gtk.Label({
         label: "Snap to Grid (Floating Mode)",
         xalign: 0.0
@@ -155,7 +167,7 @@ function settings_dialog_view(): [AppWidgets, Gtk.Container] {
         xalign: 0.0
     })
 
-    const [inner_gap, outer_gap] = gaps_section(grid, 9);
+    const [inner_gap, outer_gap] = gaps_section(grid, 10);
 
     const settings = {
         inner_gap,
@@ -164,18 +176,19 @@ function settings_dialog_view(): [AppWidgets, Gtk.Container] {
         stacking_with_mouse: new Gtk.Switch({ halign: Gtk.Align.END }),
         smart_gaps: new Gtk.Switch({ halign: Gtk.Align.END }),
         snap_to_grid: new Gtk.Switch({ halign: Gtk.Align.END }),
+        stack_tabs_buttons: new Gtk.Switch({ halign: Gtk.Align.END }),
         window_titles: new Gtk.Switch({ halign: Gtk.Align.END }),
         show_skip_taskbar: new Gtk.Switch({ halign: Gtk.Align.END }),
         mouse_cursor_follows_active_window: new Gtk.Switch({ halign: Gtk.Align.END }),
         mouse_cursor_focus_position: build_combo(
             grid,
-            7,
+            8,
             focus.FocusPosition,
             'Mouse Cursor Focus Position',
         ),
         log_level: build_combo(
             grid,
-            8,
+            9,
             log.LOG_LEVELS,
             'Log Level',
         )
@@ -187,20 +200,23 @@ function settings_dialog_view(): [AppWidgets, Gtk.Container] {
     grid.attach(snap_label, 0, 1, 1, 1)
     grid.attach(settings.snap_to_grid, 1, 1, 1, 1)
 
-    grid.attach(smart_label, 0, 2, 1, 1)
-    grid.attach(settings.smart_gaps, 1, 2, 1, 1)
+    grid.attach(stack_tab_buttons_label, 0, 2, 1, 1)
+    grid.attach(settings.stack_tabs_buttons, 1, 2, 1, 1)
 
-    grid.attach(fullscreen_launcher_label, 0, 3, 1, 1)
-    grid.attach(settings.fullscreen_launcher, 1, 3, 1, 1)
+    grid.attach(smart_label, 0, 3, 1, 1)
+    grid.attach(settings.smart_gaps, 1, 3, 1, 1)
 
-    grid.attach(stacking_with_mouse, 0, 4, 1, 1)
-    grid.attach(settings.stacking_with_mouse, 1, 4, 1, 1)
+    grid.attach(fullscreen_launcher_label, 0, 4, 1, 1)
+    grid.attach(settings.fullscreen_launcher, 1, 4, 1, 1)
 
-    grid.attach(show_skip_taskbar_label, 0, 5, 1, 1)
-    grid.attach(settings.show_skip_taskbar, 1, 5, 1, 1)
+    grid.attach(stacking_with_mouse, 0, 5, 1, 1)
+    grid.attach(settings.stacking_with_mouse, 1, 5, 1, 1)
 
-    grid.attach(mouse_cursor_follows_active_window_label, 0, 6, 1, 1)
-    grid.attach(settings.mouse_cursor_follows_active_window, 1, 6, 1, 1)
+    grid.attach(show_skip_taskbar_label, 0, 6, 1, 1)
+    grid.attach(settings.show_skip_taskbar, 1, 6, 1, 1)
+
+    grid.attach(mouse_cursor_follows_active_window_label, 0, 7, 1, 1)
+    grid.attach(settings.mouse_cursor_follows_active_window, 1, 7, 1, 1)
 
     return [settings, grid]
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -57,6 +57,7 @@ const GAP_INNER = "gap-inner";
 const GAP_OUTER = "gap-outer";
 const ROW_SIZE = "row-size";
 const SHOW_TITLE = "show-title";
+const SHOW_STACK_TAB_BUTTONS = "show-stack-tab-buttons";
 const SMART_GAPS = "smart-gaps";
 const SNAP_TO_GRID = "snap-to-grid";
 const TILE_BY_DEFAULT = "tile-by-default";
@@ -143,6 +144,10 @@ export class ExtensionSettings {
         return this.ext.get_boolean(SHOW_TITLE);
     }
 
+    show_stack_tab_buttons(): boolean {
+        return this.ext.get_boolean(SHOW_STACK_TAB_BUTTONS);
+    }
+
     smart_gaps(): boolean {
         return this.ext.get_boolean(SMART_GAPS);
     }
@@ -227,6 +232,10 @@ export class ExtensionSettings {
 
     set_show_title(set: boolean) {
         this.ext.set_boolean(SHOW_TITLE, set);
+    }
+
+    set_show_stack_tab_buttons(set: boolean) {
+        this.ext.set_boolean(SHOW_STACK_TAB_BUTTONS, set);
     }
 
     set_smart_gaps(set: boolean) {

--- a/src/stack.ts
+++ b/src/stack.ts
@@ -17,7 +17,11 @@ const INACTIVE_TAB = 'pop-shell-tab pop-shell-tab-inactive';
 const URGENT_TAB = 'pop-shell-tab pop-shell-tab-urgent';
 const INACTIVE_TAB_STYLE = '#9B8E8A';
 
-export var TAB_HEIGHT: number = 24
+export var DEFAULT_TAB_HEIGHT: number = 24
+
+export function calculate_tabs_height(ext: Ext): number  {
+    return ext.settings.show_stack_tab_buttons() ? DEFAULT_TAB_HEIGHT * ext.dpi : 0;
+}
 
 interface Tab {
     active: boolean;
@@ -134,7 +138,7 @@ export class Stack {
 
     buttons: a.Arena<TabButton> = new Arena();
 
-    tabs_height: number = TAB_HEIGHT;
+    tabs_height: number = 0;
 
     stack_rect: Rectangular = { width: 0, height: 0, x: 0, y: 0 };
 
@@ -151,7 +155,7 @@ export class Stack {
         this.active = active;
         this.monitor = monitor;
         this.workspace = workspace;
-        this.tabs_height = TAB_HEIGHT * this.ext.dpi;
+        this.tabs_height = calculate_tabs_height(ext);
 
         this.widgets = stack_widgets_new();
 
@@ -251,6 +255,7 @@ export class Stack {
 
                     const tab_border_radius = this.get_tab_border_radius(idx);
                     button.set_style(`background: ${tab_color}; border-radius: ${tab_border_radius};`);
+                    button.visible = this.ext.settings.show_stack_tab_buttons();
                 }
             })
 
@@ -628,7 +633,7 @@ export class Stack {
 
         this.rect = rect;
 
-        this.tabs_height = TAB_HEIGHT * this.ext.dpi;
+        this.tabs_height = calculate_tabs_height(this.ext);
 
         this.stack_rect = {
             x: rect.x,


### PR DESCRIPTION
I am personally not a fan of those tab buttons that are presented when windows are stacked.
![grafik](https://user-images.githubusercontent.com/13301287/205146556-c1cb4e0d-0081-4cef-a86f-03bfd9273d6f.png)

The other window tiling manager that I am used to comes without these which is totally fine, too. Take https://ianyh.com/amethyst/ as example.

So let's give users the choice :)