### PR TITLE
some targets should be run serially

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,3 +83,5 @@ update-repository:
 
 zip-file: all
 	cd _build && zip -qr "../$(UUID)_$(VERSION).zip" .
+
+.NOTPARALLEL: debug local-install


### PR DESCRIPTION
On some systems, "make" is configured to run parallelly by default. Here, debug and local-install should always be run serially.