### PR TITLE
fix: actor_exists conditional flipped for destroying property

### DIFF
--- a/src/window.ts
+++ b/src/window.ts
@@ -127,7 +127,7 @@ export class ShellWindow {
     }
 
     actor_exists(): boolean {
-        return this.meta.get_compositor_private() !== null || this.destroying;
+        return this.meta.get_compositor_private() !== null || !this.destroying;
     }
 
     private bind_window_events() {


### PR DESCRIPTION
There's a typo in the conditional check. It should be `|| !this.destroying` so that an actor being destroyed is always assumed to no longer exist. The behavior here is virtually identical to what it was doing before, since the actor does exist when it's not yet destroyed.