### PR TITLE
Option to disable stacking with mouse

### DIFF
--- a/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
@@ -74,6 +74,11 @@
             <summary>Tile launched windows by default</summary>
         </key>
 
+        <key type="b" name="stacking-with-mouse">
+            <default>true</default>
+            <summary>Allow for stacking windows as a result of dragging a window with mouse</summary>
+        </key>
+
         <!-- Focus Shifting -->
         <key type="as" name="focus-left">
             <default><![CDATA[['<Super>Left','<Super>KP_Left','<Super>h']]]></default>

--- a/src/auto_tiler.ts
+++ b/src/auto_tiler.ts
@@ -408,7 +408,7 @@ export class AutoTiler {
                 ? fork.area
                 : attach_to.meta.get_frame_rect()
 
-        let placement: null | MoveBy = cursor_placement(attach_area, cursor)
+        let placement: null | MoveBy = cursor_placement(ext, attach_area, cursor)
         const stack = ext.auto_tiler?.find_stack(attach_to.entity)
 
         const matching_stack = win.stack !== null && win.stack === attach_to.stack
@@ -733,11 +733,11 @@ export class AutoTiler {
 *
 * A null indicates that the window should be stacked
 */
-export function cursor_placement(area: Rectangular, cursor: Rectangular): null | MoveByCursor {
+export function cursor_placement(ext: Ext, area: Rectangular, cursor: Rectangular): null | MoveByCursor {
     const { LEFT, RIGHT, TOP, BOTTOM } = geom.Side
     const { HORIZONTAL, VERTICAL } = lib.Orientation
 
-    const [, side] = geom.nearest_side([cursor.x, cursor.y], area)
+    const [, side] = geom.nearest_side(ext, [cursor.x, cursor.y], area)
 
     let res: null | [lib.Orientation, boolean] = side === LEFT
         ? [HORIZONTAL, true]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1469,7 +1469,7 @@ export class Ext extends Ecs.System<ExtEvent> {
 
                     const result = monitor_attachment
                         ? null
-                        : auto_tiler.cursor_placement(area, cursor)
+                        : auto_tiler.cursor_placement(this, area, cursor)
 
                     if (!result) {
                         this.overlay.x = area.x

--- a/src/geom.ts
+++ b/src/geom.ts
@@ -1,3 +1,5 @@
+import type {Ext} from 'extension';
+
 export enum Side {
     LEFT,
     TOP,
@@ -70,7 +72,7 @@ export function leftward_distance(win_a: Meta.Window, win_b: Meta.Window) {
     return directional_distance(win_a.get_frame_rect(), win_b.get_frame_rect(), east, west);
 }
 
-export function nearest_side(origin: [number, number], rect: Rectangular): [number, Side] {
+export function nearest_side(ext: Ext, origin: [number, number], rect: Rectangular): [number, Side] {
     const left = west(rect), top = north(rect), right = east(rect), bottom = south(rect), ctr = center(rect)
 
     const left_distance = distance(origin, left),
@@ -85,7 +87,7 @@ export function nearest_side(origin: [number, number], rect: Rectangular): [numb
 
     if (top_distance < nearest[0]) nearest = [top_distance, Side.TOP]
     if (bottom_distance < nearest[0]) nearest = [bottom_distance, Side.BOTTOM]
-    if (center_distance < nearest[0]) nearest = [center_distance, Side.CENTER]
+    if (ext.settings.stacking_with_mouse() && center_distance < nearest[0]) nearest = [center_distance, Side.CENTER];
 
     return nearest
 }

--- a/src/geom.ts
+++ b/src/geom.ts
@@ -87,7 +87,7 @@ export function nearest_side(ext: Ext, origin: [number, number], rect: Rectangul
 
     if (top_distance < nearest[0]) nearest = [top_distance, Side.TOP]
     if (bottom_distance < nearest[0]) nearest = [bottom_distance, Side.BOTTOM]
-    if (ext.settings.stacking_with_mouse() && center_distance < nearest[0]) nearest = [center_distance, Side.CENTER];
+    if (ext.settings.stacking_with_mouse() && center_distance < nearest[0]) nearest = [center_distance, Side.CENTER]
 
     return nearest
 }

--- a/src/panel_settings.ts
+++ b/src/panel_settings.ts
@@ -16,6 +16,7 @@ export class Indicator {
     toggle_tiled : any
     toggle_titles: null | any
     toggle_active: any
+    toggle_stacking_with_mouse: any
     border_radius: any
 
     entry_gaps: any
@@ -56,6 +57,14 @@ export class Indicator {
             }
         )
 
+        this.toggle_stacking_with_mouse = toggle(
+            _("Allow stacking with mouse"),
+            ext.settings.stacking_with_mouse(),
+            (toggle) => {
+                ext.settings.set_stacking_with_mouse(toggle.state);
+            }
+        )
+
         this.entry_gaps = number_entry(
             _("Gaps"),
             ext.settings.gap_inner(),
@@ -90,6 +99,7 @@ export class Indicator {
             bm.addMenuItem(this.toggle_titles);
         }
 
+        bm.addMenuItem(this.toggle_stacking_with_mouse);
         bm.addMenuItem(this.toggle_active);
         bm.addMenuItem(this.border_radius);
 

--- a/src/panel_settings.ts
+++ b/src/panel_settings.ts
@@ -16,9 +16,7 @@ export class Indicator {
     toggle_tiled : any
     toggle_titles: null | any
     toggle_active: any
-    toggle_stacking_with_mouse: any
     border_radius: any
-
     entry_gaps: any
 
     constructor(ext: Ext) {
@@ -57,14 +55,6 @@ export class Indicator {
             }
         )
 
-        this.toggle_stacking_with_mouse = toggle(
-            _("Mouse Stacking"),
-            ext.settings.stacking_with_mouse(),
-            (toggle) => {
-                ext.settings.set_stacking_with_mouse(toggle.state);
-            }
-        )
-
         this.entry_gaps = number_entry(
             _("Gaps"),
             ext.settings.gap_inner(),
@@ -99,7 +89,6 @@ export class Indicator {
             bm.addMenuItem(this.toggle_titles);
         }
 
-        bm.addMenuItem(this.toggle_stacking_with_mouse);
         bm.addMenuItem(this.toggle_active);
         bm.addMenuItem(this.border_radius);
 

--- a/src/panel_settings.ts
+++ b/src/panel_settings.ts
@@ -17,6 +17,7 @@ export class Indicator {
     toggle_titles: null | any
     toggle_active: any
     border_radius: any
+
     entry_gaps: any
 
     constructor(ext: Ext) {

--- a/src/panel_settings.ts
+++ b/src/panel_settings.ts
@@ -58,7 +58,7 @@ export class Indicator {
         )
 
         this.toggle_stacking_with_mouse = toggle(
-            _("Allow stacking with mouse"),
+            _("Mouse Stacking"),
             ext.settings.stacking_with_mouse(),
             (toggle) => {
                 ext.settings.set_stacking_with_mouse(toggle.state);

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -14,6 +14,7 @@ import * as focus from 'focus';
 
 interface AppWidgets {
     fullscreen_launcher: any,
+    stacking_with_mouse: any,
     inner_gap: any,
     mouse_cursor_follows_active_window: any,
     outer_gap: any,
@@ -97,7 +98,13 @@ function settings_dialog_new(): Gtk.Container {
     app.fullscreen_launcher.connect('state-set', (_widget: any, state: boolean) => {
         ext.set_fullscreen_launcher(state)
         Settings.sync()
-    })
+    });
+
+    app.stacking_with_mouse.set_active(ext.stacking_with_mouse())
+    app.stacking_with_mouse.connect('state-set', (_widget: any, state: boolean) => {
+        ext.set_stacking_with_mouse(state)
+        Settings.sync()
+    });
 
     return grid;
 }
@@ -143,12 +150,18 @@ function settings_dialog_view(): [AppWidgets, Gtk.Container] {
         xalign: 0.0
     })
 
-    const [inner_gap, outer_gap] = gaps_section(grid, 8);
+    const stacking_with_mouse = new Gtk.Label({
+        label: "Allow stacking with mouse",
+        xalign: 0.0
+    })
+
+    const [inner_gap, outer_gap] = gaps_section(grid, 9);
 
     const settings = {
         inner_gap,
         outer_gap,
         fullscreen_launcher: new Gtk.Switch({ halign: Gtk.Align.END }),
+        stacking_with_mouse: new Gtk.Switch({ halign: Gtk.Align.END }),
         smart_gaps: new Gtk.Switch({ halign: Gtk.Align.END }),
         snap_to_grid: new Gtk.Switch({ halign: Gtk.Align.END }),
         window_titles: new Gtk.Switch({ halign: Gtk.Align.END }),
@@ -156,13 +169,13 @@ function settings_dialog_view(): [AppWidgets, Gtk.Container] {
         mouse_cursor_follows_active_window: new Gtk.Switch({ halign: Gtk.Align.END }),
         mouse_cursor_focus_position: build_combo(
             grid,
-            6,
+            7,
             focus.FocusPosition,
             'Mouse Cursor Focus Position',
         ),
         log_level: build_combo(
             grid,
-            7,
+            8,
             log.LOG_LEVELS,
             'Log Level',
         )
@@ -180,11 +193,14 @@ function settings_dialog_view(): [AppWidgets, Gtk.Container] {
     grid.attach(fullscreen_launcher_label, 0, 3, 1, 1)
     grid.attach(settings.fullscreen_launcher, 1, 3, 1, 1)
 
-    grid.attach(show_skip_taskbar_label, 0, 4, 1, 1)
-    grid.attach(settings.show_skip_taskbar, 1, 4, 1, 1)
+    grid.attach(stacking_with_mouse, 0, 4, 1, 1)
+    grid.attach(settings.stacking_with_mouse, 1, 4, 1, 1)
 
-    grid.attach(mouse_cursor_follows_active_window_label, 0, 5, 1, 1)
-    grid.attach(settings.mouse_cursor_follows_active_window, 1, 5, 1, 1)
+    grid.attach(show_skip_taskbar_label, 0, 5, 1, 1)
+    grid.attach(settings.show_skip_taskbar, 1, 5, 1, 1)
+
+    grid.attach(mouse_cursor_follows_active_window_label, 0, 6, 1, 1)
+    grid.attach(settings.mouse_cursor_follows_active_window, 1, 6, 1, 1)
 
     return [settings, grid]
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -49,6 +49,7 @@ function settings_new_schema(schema: string): Settings {
 
 const ACTIVE_HINT = "active-hint";
 const ACTIVE_HINT_BORDER_RADIUS = "active-hint-border-radius";
+const STACKING_WITH_MOUSE = "stacking-with-mouse";
 const COLUMN_SIZE = "column-size";
 const EDGE_TILING = "edge-tiling";
 const FULLSCREEN_LAUNCHER = "fullscreen-launcher"
@@ -80,6 +81,10 @@ export class ExtensionSettings {
 
     active_hint_border_radius(): number {
         return this.ext.get_uint(ACTIVE_HINT_BORDER_RADIUS);
+    }
+
+    stacking_with_mouse(): boolean {
+        return this.ext.get_boolean(STACKING_WITH_MOUSE);
     }
 
     column_size(): number {
@@ -180,6 +185,10 @@ export class ExtensionSettings {
 
     set_active_hint_border_radius(set: number) {
         this.ext.set_uint(ACTIVE_HINT_BORDER_RADIUS, set);
+    }
+
+    set_stacking_with_mouse(set: boolean) {
+        this.ext.set_boolean(STACKING_WITH_MOUSE, set);
     }
 
     set_column_size(size: number) {


### PR DESCRIPTION
I am often stacking windows by mistake when dragging and dropping them using mouse. This PR adds an option to disable Mouse Stacking entirely. However, stacking is still available if activated explicitly with Super+S. One can then move windows between stacks using keyboard shortcuts instead of mouse.

![image](https://user-images.githubusercontent.com/43541355/217563409-55ab1b28-2db3-4e1a-b670-25aa4bdf3169.png)

I believe this might be the answer for the following issues:
* https://github.com/pop-os/shell/issues/965
* https://github.com/pop-os/shell/issues/1491