### PR TITLE
Extension breaks when stacked window is destroyed

### DIFF
--- a/src/window.ts
+++ b/src/window.ts
@@ -127,7 +127,7 @@ export class ShellWindow {
     }
 
     actor_exists(): boolean {
-        return this.meta.get_compositor_private() !== null || !this.destroying;
+        return !this.destroying && this.meta.get_compositor_private() !== null;
     }
 
     private bind_window_events() {


### PR DESCRIPTION
Fixes a regression from the last commit which can cause windows in a stack being destroyed to break the extension. The conditional would consider an actorless window to have an actor if it's not yet marked as being destroyed. This'll correctly require that a window must have an actor and must not be set as destroying.