### PR TITLE
move gjs from DEFAULT_FLOAT_RULES to SKIPTASKBAR_EXCEPTIONS

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -44,7 +44,6 @@ export const DEFAULT_FLOAT_RULES: Array<FloatRule> = [
     { class: "TelegramDesktop", title: "Media viewer" },
     { class: "Zotero", title: "Quick Format Citation" },
     { class: "firefox", title: "^(?!.*Mozilla Firefox).*$" },
-    { class: "gjs" },
     { class: "gnome-screenshot" },
     { class: "ibus-.*" },
     { class: "jetbrains-toolbox" },
@@ -73,6 +72,7 @@ export interface WindowRule {
  */
 export const SKIPTASKBAR_EXCEPTIONS: Array<WindowRule> = [
     { class: "Conky", },
+    { class: "gjs" },
     { class: "Guake", },
     { class: "Com.github.amezin.ddterm", },
     { class: "plank", },


### PR DESCRIPTION
When pop-shell is installed alongside desktop-icons NG and "Show Minimize to Tray Windows" is enabled, gjs shows up as an application in the alt-tab menu (like in this previous bug: https://github.com/pop-os/shell/issues/1056). By completely moving it to the SKIPTASKBAR_EXCEPTIONS it gets resolved/no longer shows up when the option is enabled.