### PR TITLE
re-add gjs to DEFAULT_FLOAT_RULES

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -56,7 +56,8 @@ export const DEFAULT_FLOAT_RULES: Array<FloatRule> = [
     { class: "system76-driver" },
     { class: "tilda" },
     { class: "zoom" },
-    { class: "^.*action=join.*$"}
+    { class: "^.*action=join.*$"},
+    { class: "gjs" }
 
 ];
 


### PR DESCRIPTION
This is to fix https://github.com/pop-os/shell/issues/1608 which affects Wayland, and was caused by https://github.com/pop-os/shell/pull/1605.

https://github.com/pop-os/shell/pull/1605 fixed https://github.com/pop-os/shell/issues/1056 by moving `gjs` from `DEFAULT_FLOAT_RULES` to `SKIPTASKBAR_EXCEPTIONS`.

By keeping `gjs` in both it appears to resolve both issues.

To test in X11:
- install https://extensions.gnome.org/extension/4337/desktop-icons-neo/
- right click on the Desktop and select `Desktop Icon Settings`
- with `Desktop Icon Settings` window open `Alt` + `Tab`

There should not be any blank `gjs` icon showing.

To test in Wayland:
- while logged into Wayland enable tiling
- open a window on the first workspace
- open a window on the second workspace

Both should now take up the whole workspace and not just half as described in https://github.com/pop-os/shell/issues/1608.
