### PR TITLE
fix: update GrabOp classification for GNOME 44

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,7 +45,7 @@ const GLib: GLib = imports.gi.GLib;
 
 const { Gio, Meta, St, Shell } = imports.gi;
 const { GlobalEvent, WindowEvent } = Events;
-const { cursor_rect, is_move_op } = Lib;
+const { cursor_rect, ignore_unconstrained_bit, is_move_op } = Lib;
 const Main = imports.ui.main;
 const { layoutManager, loadTheme, overview, panel, setThemeStylesheet, screenShield, sessionMode, windowAttentionHandler } = Main;
 const { ScreenShield } = imports.ui.screenShield;
@@ -1110,7 +1110,7 @@ export class Ext extends Ecs.System<ExtEvent> {
         if (this.auto_tiler) {
             let crect = win.rect()
             const rect = grab_op.rect;
-            if (is_move_op(op)) {
+            if (is_move_op(ignore_unconstrained_bit(op))) {
                 const cmon = win.meta.get_monitor()
                 const prev_mon = this.monitors.get(win.entity)
                 const mon_drop = prev_mon ? prev_mon[0] !== cmon : false
@@ -1411,7 +1411,7 @@ export class Ext extends Ecs.System<ExtEvent> {
 
                 /** Display an overlay indicating where the window will be placed if dropped */
 
-                if (overview.visible || !win || op !== 1) return
+                if (overview.visible || !win || ignore_unconstrained_bit(op) !== 1) return
 
                 const workspace = this.active_workspace();
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,7 +45,7 @@ const GLib: GLib = imports.gi.GLib;
 
 const { Gio, Meta, St, Shell } = imports.gi;
 const { GlobalEvent, WindowEvent } = Events;
-const { cursor_rect, ignore_unconstrained_bit, is_move_op } = Lib;
+const { cursor_rect, is_keyboard_op, is_resize_op, is_move_op } = Lib;
 const Main = imports.ui.main;
 const { layoutManager, loadTheme, overview, panel, setThemeStylesheet, screenShield, sessionMode, windowAttentionHandler } = Main;
 const { ScreenShield } = imports.ui.screenShield;
@@ -1110,7 +1110,7 @@ export class Ext extends Ecs.System<ExtEvent> {
         if (this.auto_tiler) {
             let crect = win.rect()
             const rect = grab_op.rect;
-            if (is_move_op(ignore_unconstrained_bit(op))) {
+            if (is_move_op(op)) {
                 const cmon = win.meta.get_monitor()
                 const prev_mon = this.monitors.get(win.entity)
                 const mon_drop = prev_mon ? prev_mon[0] !== cmon : false
@@ -1411,7 +1411,7 @@ export class Ext extends Ecs.System<ExtEvent> {
 
                 /** Display an overlay indicating where the window will be placed if dropped */
 
-                if (overview.visible || !win || ignore_unconstrained_bit(op) !== 1) return
+                if (overview.visible || !win || is_keyboard_op(op) || is_resize_op(op)) return
 
                 const workspace = this.active_workspace();
 

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -86,6 +86,11 @@ export function join<T>(iterator: IterableIterator<T>, next_func: (arg: T) => vo
     });
 }
 
+export function ignore_unconstrained_bit(op: number): number {
+    const unconstrained_bit = Meta.GrabOp.MOVING ^ Meta.GrabOp.MOVING_UNCONSTRAINED;
+    return op & ~unconstrained_bit;
+}
+
 export function is_move_op(op: number): boolean {
     return [
         Meta.GrabOp.WINDOW_BASE,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -86,17 +86,18 @@ export function join<T>(iterator: IterableIterator<T>, next_func: (arg: T) => vo
     });
 }
 
-export function ignore_unconstrained_bit(op: number): number {
-    const unconstrained_bit = Meta.GrabOp.MOVING ^ Meta.GrabOp.MOVING_UNCONSTRAINED;
-    return op & ~unconstrained_bit;
+export function is_keyboard_op(op: number): boolean {
+    const window_flag_keyboard = Meta.GrabOp.KEYBOARD_MOVING & ~Meta.GrabOp.WINDOW_BASE;
+    return (op & window_flag_keyboard) != 0;
+}
+
+export function is_resize_op(op: number): boolean {
+    const window_dir_mask = (Meta.GrabOp.RESIZING_N | Meta.GrabOp.RESIZING_E | Meta.GrabOp.RESIZING_S | Meta.GrabOp.RESIZING_W) & ~Meta.GrabOp.WINDOW_BASE;
+    return (op & window_dir_mask) != 0 || (op & Meta.GrabOp.KEYBOARD_RESIZING_UNKNOWN) == Meta.GrabOp.KEYBOARD_RESIZING_UNKNOWN;
 }
 
 export function is_move_op(op: number): boolean {
-    return [
-        Meta.GrabOp.WINDOW_BASE,
-        Meta.GrabOp.MOVING,
-        Meta.GrabOp.KEYBOARD_MOVING
-    ].indexOf(op) > -1;
+    return !is_resize_op(op)
 }
 
 export function orientation_as_str(value: number): string {


### PR DESCRIPTION
Fixes #1615, which is broken due to updates in Clutter's Grab handling behavior in GNOME/Mutter 44. This is described in this merge request (https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/2683), and specifically caused by this commit (https://gitlab.gnome.org/GNOME/mutter/-/commit/12773cf8e2954082f346dee300af624b25baf23c)

More concretely, a new `META_GRAB_OP_WINDOW_FLAG_UNCONSTRAINED` flag is added, which should be ignored when determining if a grab op is a move op or not. Unfortunately, this flag is not exposed publicly, and is not backwards compatible with prior versions of GNOME.

The most principled way to fix this is to use these functions in mutter's `display.c` (https://gitlab.gnome.org/GNOME/mutter/-/blob/main/src/core/display.c#L1186), but these are also not public. I've reimplemented here in JS, with some more bit operations to recover the flags that are used. This may not be the most maintainable way to do this, am open to comments.

This works on Fedora 38 (GNOME 44) and Fedora 37 (GNOME 43), although I haven't tested anything older.

[f38_postcommit.webm](https://user-images.githubusercontent.com/7400724/233483438-d619efb6-57db-47dd-a559-e60e794c0bdf.webm)
[f37_postcommit.webm](https://user-images.githubusercontent.com/7400724/233483932-c129f4e1-e857-4348-921d-63d818854739.webm)
