### PR TITLE
fix: correctly hide the decoration on gnome 44 (#1622)

### DIFF
--- a/src/xprop.ts
+++ b/src/xprop.ts
@@ -7,7 +7,7 @@ const GLib: GLib = imports.gi.GLib;
 const { spawn } = imports.misc.util;
 
 export var MOTIF_HINTS: string = '_MOTIF_WM_HINTS';
-export var HIDE_FLAGS: string[] = ['0x2', '0x0', '0x2', '0x0', '0x0'];
+export var HIDE_FLAGS: string[] = ['0x2', '0x0', '0x0', '0x0', '0x0'];
 export var SHOW_FLAGS: string[] = ['0x2', '0x0', '0x1', '0x0', '0x0'];
 
 export function get_window_role(xid: string): string | null {


### PR DESCRIPTION
This PR fixes #1622 and is based on the suggestion https://github.com/velitasali/gtktitlebar/issues/36#issuecomment-1455278899