### PR TITLE
improve(makefile): detect wayland on restart after build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,12 @@ $(info UUID is "$(UUID)")
 
 sources = src/*.ts *.css
 
+ifeq ($(XDG_SESSION_TYPE),wayland)
+RESTART_COMMAND = killall -u $(USER)
+else
+RESTART_COMMAND = pkill -HUP gnome-shell
+endif
+
 all: depcheck compile
 
 clean:
@@ -70,7 +76,7 @@ uninstall:
 restart-shell:
 	echo "Restart shell!"
 	if bash -c 'xprop -root &> /dev/null'; then \
-		pkill -HUP gnome-shell; \
+		$(RESTART_COMMAND); \
 	else \
 		gnome-session-quit --logout; \
 	fi


### PR DESCRIPTION
Wayland doesn't support session restart, so a different approach has to be taken in order to prevent a blank screen that requires the user to start a new TTL and reboot (if she/he knows how to do it), or to force shutdown by holding down the power button.

Tested on Debian 12, 
Linux lt-5 6.1.0-12-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.52-1 (2023-09-07) x86_64 GNU/Linux
