### PR TITLE
Fix the title bar showing/hiding

### DIFF
--- a/src/xprop.ts
+++ b/src/xprop.ts
@@ -77,7 +77,7 @@ export function get_xid(meta: Meta.Window): string | null {
 
 export function may_decorate(xid: string): boolean {
     const hints = motif_hints(xid);
-    return Array.isArray(hints);
+    return hints ? hints[2] == '0x0' || hints[2] == '0x1' : true;
 }
 
 export function motif_hints(xid: string): Array<string> | null {

--- a/src/xprop.ts
+++ b/src/xprop.ts
@@ -7,7 +7,7 @@ const GLib: GLib = imports.gi.GLib;
 const { spawn } = imports.misc.util;
 
 export var MOTIF_HINTS: string = '_MOTIF_WM_HINTS';
-export var HIDE_FLAGS: string[] = ['0x2', '0x0', '0x2', '0x0', '0x0'];
+export var HIDE_FLAGS: string[] = ['0x2', '0x0', '0x0', '0x0', '0x0'];
 export var SHOW_FLAGS: string[] = ['0x2', '0x0', '0x1', '0x0', '0x0'];
 
 export function get_window_role(xid: string): string | null {
@@ -77,7 +77,7 @@ export function get_xid(meta: Meta.Window): string | null {
 
 export function may_decorate(xid: string): boolean {
     const hints = motif_hints(xid);
-    return hints ? hints[2] != '0x0' : true;
+    return Array.isArray(hints);
 }
 
 export function motif_hints(xid: string): Array<string> | null {


### PR DESCRIPTION
This is based off #1625 so Closes #1622 and #1625

I tested it on gnome 42 and 44 and it works on both, the only difference in the PRs is the change to the `may_decorate` functions. I'm not 100% sure what this function does but my best guess is to avoid adding `_MOTIF_WM_HINTS` if some other application has already done that. I adapted this check to include that the flags being set by pop shell are now `0x0` and `0x1`.

If this PR is good to go I'll also raise the exact same change for g45 on `master_mantic`