### PR TITLE
fix: Settings display

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2664,8 +2664,13 @@ export class Ext extends Ecs.System<ExtEvent> {
 let ext: Ext | null = null;
 let indicator: Indicator | null = null;
 
+declare global {
+  var popShellExtension: any;
+}
+
 export default class PopShellExtension extends Extension {
     enable() {
+        globalThis.popShellExtension  = this;
         log.info('enable');
 
         if (!ext) {
@@ -2714,6 +2719,7 @@ export default class PopShellExtension extends Extension {
                 return;
             }
 
+            delete globalThis.popShellExtension;
             ext.injections_remove();
             ext.signals_remove();
             ext.exit_modes();

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,5 +1,3 @@
-import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
-
 // simplified log4j levels
 export enum LOG_LEVELS {
     OFF,
@@ -16,7 +14,7 @@ export function log_level() {
     // log.js is at the level of prefs.js where the popshell Ext instance
     // is not yet available or visible, so we have to use the built in
     // ExtensionUtils to get the current settings
-    let settings = Extension.lookupByURL(import.meta.url).getSettings();
+    let settings = globalThis.popShellExtension.getSettings();
     let log_level = settings.get_uint('log-level');
 
     return log_level;

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -24,6 +24,7 @@ interface AppWidgets {
 
 export default class PopShellPreferences extends ExtensionPreferences {
     getPreferencesWidget() {
+        globalThis.popShellExtension = this;
         let dialog = settings_dialog_new();
         if (dialog.show_all) {
             dialog.show_all();


### PR DESCRIPTION
This is a little hacky way to fix the issue with the preferences pane not displaying with GNOME45. Please note in the prefs case the assignment is not cleared on close. This can be done but requires a bigger rewrite to the prefs code.

Closes #1663