### PR TITLE
Don't restart if running Wayland

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,13 +68,17 @@ uninstall:
 	rm -rf $(INSTALLBASE)/$(INSTALLNAME)
 
 restart-shell:
-	echo "Restart shell!"
+	@echo "Restart shell!"
+ifneq ($(WAYLAND_DISPLAY),) # Don't restart if WAYLAND_DISPLAY is set
+	@echo "WAYLAND_DISPLAY is set, not restarting shell";
+else
 	if bash -c 'xprop -root &> /dev/null'; then \
 		pkill -HUP gnome-shell; \
 	else \
 		gnome-session-quit --logout; \
 	fi
 	sleep 3
+endif
 
 update-repository:
 	git fetch origin


### PR DESCRIPTION
On wayland, running `make local-install` kills Wayland without restarting it properly. This was experienced in  #1552 and #1584 among other reports. We can detect Wayland and skip the restart if we know it's going to cause problems.

Fixes #1584