### PR TITLE
fix: make launcher entries expandable

### DIFF
--- a/src/search.ts
+++ b/src/search.ts
@@ -429,7 +429,7 @@ export class SearchOption {
         this.exec = exec;
         this.keywords = keywords;
 
-        const layout = new St.BoxLayout({});
+        const layout = new St.BoxLayout({ x_expand: true });
 
         attach_icon(layout, category_icon, icon_size / 2);
 


### PR DESCRIPTION
Can't really tell why this broke. At first I thought this was due to changes of `St.Bin` default expand properties, but `St.BoxLayout` isn't descendant of it. Setting `x_expand` on the button itself didn't fix this.

fixes #1706 