### PR TITLE
docs (mantic): Update list of GNOME versions & branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,15 +62,16 @@ There are additionally those who do want the traditional stacking window managem
 
 ## Installation
 
-To install this GNOME Shell extension, you MUST have the following:
+Use the branch corresponding to your GNOME Shell version (`git checkout branch_name`):
 
-- GNOME Shell 3.36
-- TypeScript 3.8
-- GNU Make
+- **GNOME 3.36 through 41:** Use the `master_focal` branch.
+- **GNOME 42 through 44:** Use the `master_jammy` branch.
+- **GNOME 45:** Use the `master_mantic` branch.
+- **GNOME 46+:** Use the `master_noble` branch.
+
+GNU Make and TypeScript are also required to build the project.
 
 Proper functionality of the shell requires modifying GNOME's default keyboard shortcuts. For a local installation, run `make local-install`.
-
-The `master_mantic` git branch corresponds to Ubuntu 23.10 and supports GNOME 45+. For GNOME 3.36 through 44 support, use the `master_jammy` branch.
 
 If you want to uninstall the extension, you may invoke `make uninstall`, and then open the "Keyboard Shortcuts" panel in GNOME Settings to select the "Reset All.." button in the header bar.
 


### PR DESCRIPTION
Applies https://github.com/pop-os/shell/pull/1731 to the Mantic readme.