### PR TITLE
fix: "Tile Windows" toggle causing recursion when using shortcut

### DIFF
--- a/src/panel_settings.ts
+++ b/src/panel_settings.ts
@@ -308,13 +308,13 @@ function show_title(ext: Ext): any {
     return t;
 }
 
-function toggle(desc: string, active: boolean, connect: (toggle: any) => void): any {
+function toggle(desc: string, active: boolean, connect: (toggle: any, state: boolean) => void): any {
     let toggle = new PopupSwitchMenuItem(desc, active);
 
     toggle.label.set_y_align(Clutter.ActorAlign.CENTER);
 
-    toggle.connect('toggled', () => {
-        connect(toggle);
+    toggle.connect('toggled', (_: any, state: boolean) => {
+        connect(toggle, state);
         return true;
     });
 
@@ -322,7 +322,13 @@ function toggle(desc: string, active: boolean, connect: (toggle: any) => void): 
 }
 
 function tiled(ext: Ext): any {
-    let t = toggle(_('Tile Windows'), null != ext.auto_tiler, () => ext.toggle_tiling());
+    let t = toggle(_('Tile Windows'), null != ext.auto_tiler, (_, shouldTile) => {
+        if (shouldTile) {
+            ext.auto_tile_on();
+        } else {
+            ext.auto_tile_off();
+        }
+    });
     return t;
 }
 


### PR DESCRIPTION
Fixes #1733, it was an infinite recursion issue [that was caused by updating the state for the "Tile Windows" toggle in the indicator popup.](https://github.com/pop-os/shell/issues/1733#issuecomment-2524836497)

I fixed this by calling the appropriate `auto_tile_*` method inside the `connect` callback for the toggle. If this isn't the preferred way to go about it, then I'm happy to change it.

Works on my machine, even if I press and hold the `toggle-tiling` shortcut key combination.