### PR TITLE
Add max window width

### DIFF
--- a/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
@@ -79,6 +79,11 @@
             <summary>Allow for stacking windows as a result of dragging a window with mouse</summary>
         </key>
 
+        <key type="u" name="max-window-width">
+            <default>0</default>
+            <summary>Maximum size of tiled windows (0 to disable)</summary>
+        </key>
+
         <!-- Focus Shifting -->
         <key type="as" name="focus-left">
             <default><![CDATA[['<Super>Left','<Super>KP_Left','<Super>h']]]></default>

--- a/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
@@ -20,12 +20,12 @@
 
         <key type="u" name="gap-inner">
             <default>2</default>
-            <summary>Gap between tiled windows</summary>
+            <summary>Gap between tiled windows, in pixels</summary>
         </key>
 
         <key type="u" name="gap-outer">
             <default>2</default>
-            <summary>Gap surrounding tiled windows</summary>
+            <summary>Gap surrounding tiled windows, in pixels</summary>
         </key>
 
         <key type="b" name="show-title">
@@ -81,7 +81,7 @@
 
         <key type="u" name="max-window-width">
             <default>0</default>
-            <summary>Maximum size of tiled windows (0 to disable)</summary>
+            <summary>Maximum width of tiled windows, in pixels (0 to disable)</summary>
         </key>
 
         <!-- Focus Shifting -->

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -173,7 +173,7 @@ function settings_dialog_view(): [AppWidgets, Gtk.Container] {
     });
 
     const max_window_width_label = new Gtk.Label({
-        label: 'Max window width (0 to disable)',
+        label: 'Max window width (in pixels); 0 to disable',
         xalign: 0.0,
     });
 
@@ -239,7 +239,7 @@ function gaps_section(grid: any, top: number): [any, any] {
     let inner_entry = number_entry();
 
     let section_label = new Gtk.Label({
-        label: 'Gaps',
+        label: 'Gaps (in pixels)',
         xalign: 0.0,
     });
 

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -20,6 +20,7 @@ interface AppWidgets {
     window_titles: any;
     mouse_cursor_focus_position: any;
     log_level: any;
+    max_window_width: any;
 }
 
 export default class PopShellPreferences extends ExtensionPreferences {
@@ -113,6 +114,15 @@ function settings_dialog_new(): Gtk.Container {
         Settings.sync();
     });
 
+    app.max_window_width.set_text(String(ext.max_window_width()));
+    app.max_window_width.connect('activate', (widget: any) => {
+        let parsed = parseInt((widget.get_text() as string).trim());
+        if (!isNaN(parsed)) {
+            ext.set_max_window_width(parsed);
+            Settings.sync();
+        }
+    });
+
     return grid;
 }
 
@@ -162,6 +172,11 @@ function settings_dialog_view(): [AppWidgets, Gtk.Container] {
         xalign: 0.0,
     });
 
+    const max_window_width_label = new Gtk.Label({
+        label: 'Max window width (0 to disable)',
+        xalign: 0.0,
+    });
+
     const [inner_gap, outer_gap] = gaps_section(grid, 9);
 
     const settings = {
@@ -176,6 +191,7 @@ function settings_dialog_view(): [AppWidgets, Gtk.Container] {
         mouse_cursor_follows_active_window: new Gtk.Switch({ halign: Gtk.Align.END }),
         mouse_cursor_focus_position: build_combo(grid, 7, focus.FocusPosition, 'Mouse Cursor Focus Position'),
         log_level: build_combo(grid, 8, log.LOG_LEVELS, 'Log Level'),
+        max_window_width: number_entry(),
     };
 
     grid.attach(win_label, 0, 0, 1, 1);
@@ -198,6 +214,9 @@ function settings_dialog_view(): [AppWidgets, Gtk.Container] {
 
     grid.attach(mouse_cursor_follows_active_window_label, 0, 6, 1, 1);
     grid.attach(settings.mouse_cursor_follows_active_window, 1, 6, 1, 1);
+
+    grid.attach(max_window_width_label, 0, 12, 1, 1);
+    grid.attach(settings.max_window_width, 1, 12, 1, 1);
 
     return [settings, grid];
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -68,6 +68,7 @@ const LOG_LEVEL = 'log-level';
 const SHOW_SKIPTASKBAR = 'show-skip-taskbar';
 const MOUSE_CURSOR_FOLLOWS_ACTIVE_WINDOW = 'mouse-cursor-follows-active-window';
 const MOUSE_CURSOR_FOCUS_LOCATION = 'mouse-cursor-focus-location';
+const MAX_WINDOW_WIDTH = 'max-window-width';
 
 export class ExtensionSettings {
     ext: Settings = settings_new_schema('org.gnome.shell.extensions.pop-shell');
@@ -173,6 +174,10 @@ export class ExtensionSettings {
         return this.ext.get_uint(MOUSE_CURSOR_FOCUS_LOCATION);
     }
 
+    max_window_width(): number {
+        return this.ext.get_uint(MAX_WINDOW_WIDTH);
+    }
+
     // Setters
 
     set_active_hint(set: boolean) {
@@ -251,5 +256,9 @@ export class ExtensionSettings {
 
     set_mouse_cursor_focus_location(set: number) {
         this.ext.set_uint(MOUSE_CURSOR_FOCUS_LOCATION, set);
+    }
+
+    set_max_window_width(set: number) {
+        this.ext.set_uint(MAX_WINDOW_WIDTH, set);
     }
 }

--- a/src/window.ts
+++ b/src/window.ts
@@ -63,7 +63,7 @@ export class ShellWindow {
     ignore_detach: boolean = false;
     was_attached_to?: [Entity, boolean | number];
     destroying: boolean = false;
-    
+
     // Awaiting reassignment after a display update
     reassignment: boolean = false;
 
@@ -269,7 +269,7 @@ export class ShellWindow {
         // look I guess I'll hack something together in here if at all possible
         // Because Meta.Window.is_client_decorated() was removed in Meta 15, using it breaks the extension in gnome 47 or higher
         //return this.meta.window_type == Meta.WindowType.META_WINDOW_OVERRIDE_OTHER;
-        const xid = this.xid()
+        const xid = this.xid();
         const extents = xid ? xprop.get_frame_extents(xid) : false;
         if (!extents) return false;
         return true;
@@ -360,6 +360,13 @@ export class ShellWindow {
         }
 
         this.hide_border();
+
+        const max_width = ext.settings.max_window_width();
+        if (max_width > 0 && rect.width > max_width) {
+            rect.x += (rect.width - max_width) / 2;
+            rect.width = max_width;
+        }
+
         const clone = Rect.Rectangle.from_meta(rect);
         const meta = this.meta;
         const actor = meta.get_compositor_private();


### PR DESCRIPTION
See #1752

This PR adds the option to limit the maximum width of tiled windows. It is especially useful on ultrawide monitors.

The user can define the width in the extension settings. If a window exceeds the specified maximum width, it will be reduced to the max size and centered within the allotted space.
