### PR TITLE
fix: Avoid Gdk.DisplayManager usage in place_pointer_on() to prevent "gdk_display_manager_get() was called before gtk_init()" crash (#1769)

### DIFF
--- a/src/mod.d.ts
+++ b/src/mod.d.ts
@@ -212,6 +212,7 @@ declare namespace Clutter {
         set_position(x: number, y: number): void;
         set_size(width: number, height: number): void;
         show(): void;
+        get_context(): Clutter.Context;
     }
 
     interface ActorBox {
@@ -221,6 +222,18 @@ declare namespace Clutter {
     interface Text extends Actor {
         get_text(): Readonly<string>;
         set_text(text: string | null): void;
+    }
+
+    interface Seat extends GObject.Object {
+        warp_pointer(x: number, y: number): void;
+    }
+
+    interface Backend extends GObject.Object {
+        get_default_seat(): Seat;
+    }
+
+    interface Context extends GObject.Object {
+        get_backend(): Backend;
     }
 }
 

--- a/src/window.ts
+++ b/src/window.ts
@@ -764,11 +764,7 @@ function place_pointer_on(ext: Ext, win: Meta.Window) {
             y += 8;
     }
 
-    const display = Gdk.DisplayManager.get().get_default_display();
-
-    if (display) {
-        display.get_default_seat().get_pointer().warp(display.get_default_screen(), x, y);
-    }
+    global.stage.get_context().get_backend().get_default_seat().warp_pointer(x, y);
 }
 
 function pointer_already_on_window(meta: Meta.Window): boolean {


### PR DESCRIPTION
Avoid Gdk.DisplayManager usage in place_pointer_on() to prevent "gdk_display_manager_get() was called before gtk_init()" crash (#1769)