### PR TITLE
Fix gnome 49 compatibility

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -909,10 +909,10 @@ export class Ext extends Ecs.System<ExtEvent> {
             ) {
                 if (prev.rect().contains(win.rect())) {
                     if (prev.is_maximized()) {
-                        prev.meta.unmaximize(Meta.MaximizeFlags.BOTH);
+                        prev.meta.unmaximize();
                     }
                 } else if (prev.stack) {
-                    prev.meta.unmaximize(Meta.MaximizeFlags.BOTH);
+                    prev.meta.unmaximize();
                     this.auto_tiler.forest.stacks.get(prev.stack)?.restack();
                 }
             }
@@ -1034,7 +1034,7 @@ export class Ext extends Ecs.System<ExtEvent> {
                     compare.is_maximized() &&
                     win.entity[0] !== compare.entity[0]
                 ) {
-                    compare.meta.unmaximize(Meta.MaximizeFlags.BOTH);
+                    compare.meta.unmaximize();
                 }
             }
         }
@@ -1258,9 +1258,7 @@ export class Ext extends Ecs.System<ExtEvent> {
 
             if (this.auto_tiler) {
                 if (this.is_floating(win)) {
-                    win.meta.unmaximize(Meta.MaximizeFlags.HORIZONTAL);
-                    win.meta.unmaximize(Meta.MaximizeFlags.VERTICAL);
-                    win.meta.unmaximize(Meta.MaximizeFlags.BOTH);
+                    win.meta.unmaximize();
                 }
 
                 this.register(Events.window_move(this, win, rect));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2962,7 +2962,9 @@ function _show_skip_taskbar_windows(ext: Ext) {
         WindowSwitcherPopup.prototype._getWindowList = function () {
             let workspace = null;
 
-            if (this._settings.get_boolean('current-workspace-only')) {
+            // Use local settings instance since this._settings may be null in GNOME 49+
+            let settings = new Gio.Settings({ schema_id: 'org.gnome.shell.app-switcher' });
+            if (settings.get_boolean('current-workspace-only')) {
                 let workspaceManager = global.workspace_manager;
                 workspace = workspaceManager.get_active_workspace();
             }

--- a/src/mod.d.ts
+++ b/src/mod.d.ts
@@ -311,7 +311,7 @@ declare namespace Meta {
         move_resize_frame(user_op: boolean, x: number, y: number, w: number, h: number): boolean;
         raise(): void;
         skip_taskbar: boolean;
-        unmaximize(flags: any): void;
+        unmaximize(flags?: any): void;
         unminimize(): void;
     }
 

--- a/src/tiling.ts
+++ b/src/tiling.ts
@@ -749,7 +749,7 @@ export class Tiler {
             this.window = win.entity;
 
             if (win.is_maximized()) {
-                win.meta.unmaximize(Meta.MaximizeFlags.BOTH);
+                win.meta.unmaximize();
             }
 
             // Set overlay to match window

--- a/src/window.ts
+++ b/src/window.ts
@@ -373,7 +373,7 @@ export class ShellWindow {
 
         if (actor) {
             if (this.is_maximized()) {
-                meta.unmaximize(Meta.MaximizeFlags.BOTH);
+                meta.unmaximize();
             }
             actor.remove_all_transitions();
 


### PR DESCRIPTION
# Pop Shell incompatible with GNOME Shell 49

## Environment
- **OS**: Fedora 43
- **GNOME Shell**: 49.2
- **Pop Shell Version**: 2

## Problem
Pop Shell fails to work correctly on GNOME Shell 49 with the following error repeated in the journal:

```
JS WARNING: file:///home/USER/.local/share/gnome-shell/extensions/pop-shell@system76.com/window.js:264:22:
Too many arguments to method Meta.Window.unmaximize: expected 0, got 1
```

## Root Cause
The GNOME 49 API changed the `Meta.Window.unmaximize()` method signature. It no longer accepts any parameters (previously accepted `Meta.MaximizeFlags`).

## Solution
Replace all instances of:
- `unmaximize(Meta.MaximizeFlags.BOTH)`
- `unmaximize(Meta.MaximizeFlags.HORIZONTAL)`
- `unmaximize(Meta.MaximizeFlags.VERTICAL)`

with just: `unmaximize()`

## Affected Files and Lines

### window.js
- Line 264: `meta.unmaximize(Meta.MaximizeFlags.BOTH)` → `meta.unmaximize()`

### extension.js
- Line 636: `prev.meta.unmaximize(Meta.MaximizeFlags.BOTH)` → `prev.meta.unmaximize()`
- Line 640: `prev.meta.unmaximize(Meta.MaximizeFlags.BOTH)` → `prev.meta.unmaximize()`
- Line 742: `compare.meta.unmaximize(Meta.MaximizeFlags.BOTH)` → `compare.meta.unmaximize()`
- Lines 949-951: Three separate calls → single `win.meta.unmaximize()`

### tiling.js
- Line 562: `win.meta.unmaximize(Meta.MaximizeFlags.BOTH)` → `win.meta.unmaximize()`

## Testing
After applying these changes, Pop Shell works correctly on GNOME 49 with all tiling functionality restored.

## Additional Notes
The metadata.json already lists shell version 49 as supported, but the code wasn't updated for the API changes.