### PR TITLE
Fix tiled windows positioned behind top bar on workspace move

### DIFF
--- a/src/auto_tiler.ts
+++ b/src/auto_tiler.ts
@@ -95,7 +95,7 @@ export class AutoTiler {
     }
 
     update_toplevel(ext: Ext, fork: Fork, monitor: number, smart_gaps: boolean) {
-        let rect = ext.monitor_work_area(monitor);
+        let rect = ext.monitor_work_area(monitor, fork.workspace);
 
         fork.smart_gapped = smart_gaps && fork.right === null;
 
@@ -120,7 +120,7 @@ export class AutoTiler {
 
     /** Attaches `win` to an optionally-given monitor */
     attach_to_monitor(ext: Ext, win: ShellWindow, workspace_id: [number, number], smart_gaps: boolean) {
-        let rect = ext.monitor_work_area(workspace_id[0]);
+        let rect = ext.monitor_work_area(workspace_id[0], workspace_id[1]);
 
         if (!smart_gaps) {
             rect.x += ext.gap_outer;
@@ -153,7 +153,7 @@ export class AutoTiler {
             if (monitor) {
                 if (fork.is_toplevel && fork.smart_gapped && fork.right) {
                     fork.smart_gapped = false;
-                    let rect = ext.monitor_work_area(fork.monitor);
+                    let rect = ext.monitor_work_area(fork.monitor, fork.workspace);
 
                     rect.x += ext.gap_outer;
                     rect.y += ext.gap_outer;
@@ -244,7 +244,7 @@ export class AutoTiler {
             if (reflow_fork) {
                 const fork = reflow_fork[1];
                 if (fork.is_toplevel && ext.settings.smart_gaps() && fork.right === null) {
-                    let rect = ext.monitor_work_area(fork.monitor);
+                    let rect = ext.monitor_work_area(fork.monitor, fork.workspace);
                     fork.set_area(rect);
                     fork.smart_gapped = true;
                 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -749,8 +749,11 @@ export class Ext extends Ecs.System<ExtEvent> {
         this.row_size = this.settings.row_size() * this.dpi;
     }
 
-    monitor_work_area(monitor: number): Rectangle {
-        const meta = wom.get_active_workspace().get_work_area_for_monitor(monitor);
+    monitor_work_area(monitor: number, workspace_idx?: number): Rectangle {
+        const ws = workspace_idx !== undefined && workspace_idx !== null
+            ? wom.get_workspace_by_index(workspace_idx) ?? wom.get_active_workspace()
+            : wom.get_active_workspace();
+        const meta = ws.get_work_area_for_monitor(monitor);
 
         return Rect.Rectangle.from_meta(meta as Rectangular);
     }
@@ -2363,7 +2366,7 @@ export class Ext extends Ecs.System<ExtEvent> {
             for (const f of this.auto_tiler.forest.forks.values()) {
                 if (!f.is_toplevel) continue;
 
-                const display = this.monitor_work_area(f.monitor);
+                const display = this.monitor_work_area(f.monitor, f.workspace);
 
                 if (display) {
                     const area = new Rect.Rectangle([display.x, display.y, display.width, display.height]);

--- a/src/tiling.ts
+++ b/src/tiling.ts
@@ -251,7 +251,7 @@ export class Tiler {
 
         if (fork.is_toplevel && fork.smart_gapped) {
             fork.smart_gapped = false;
-            let rect = ext.monitor_work_area(fork.monitor);
+            let rect = ext.monitor_work_area(fork.monitor, fork.workspace);
 
             rect.x += ext.gap_outer;
             rect.y += ext.gap_outer;
@@ -339,7 +339,7 @@ export class Tiler {
 
         if (fork.is_toplevel && fork.smart_gapped) {
             fork.smart_gapped = false;
-            let rect = ext.monitor_work_area(fork.monitor);
+            let rect = ext.monitor_work_area(fork.monitor, fork.workspace);
 
             rect.x += ext.gap_outer;
             rect.y += ext.gap_outer;
@@ -485,7 +485,7 @@ export class Tiler {
         if (this.window) {
             const monitor_id = ext.monitors.get(this.window);
             if (monitor_id) {
-                const monitor = ext.monitor_work_area(monitor_id[0]);
+                const monitor = ext.monitor_work_area(monitor_id[0], monitor_id[1]);
                 let rect = this.rect(ext, monitor);
 
                 if (rect) {


### PR DESCRIPTION
monitor_work_area() always queries the active workspace for work area geometry, even when tiling a window that just moved to a different workspace. when a window gets moved between workspaces, the workspace-changed signal fires and pop-shell detaches + reattaches the window to the new workspace's tiling tree. during that reattach, it calls monitor_work_area() to figure out where to place the window — but since the active workspace hasn't switched yet, get_work_area_for_monitor() returns geometry for the wrong workspace. depending on timing, this can return y=0 instead of y=panel_height, so the window gets tiled behind the top bar.

the fix adds an optional workspace_idx parameter to monitor_work_area() so callers that know which workspace they're targeting can pass it explicitly instead of relying on the active workspace. all tiling codepaths that have fork/workspace context (attach_to_monitor, update_toplevel, detach_window, smart gap recalculations) now pass the actual workspace index. callers that genuinely operate on the active workspace (launcher, snap, display readiness check) are left unchanged.

this also explains why the bug is intermittent — it depends on whether gnome has finished switching the active workspace by the time the tiling code runs.

fixes #1565