### PR TITLE
Fix tiled windows positioned behind top bar on workspace move

### DIFF
--- a/src/auto_tiler.ts
+++ b/src/auto_tiler.ts
@@ -96,7 +96,7 @@ export class AutoTiler {
     }
 
     update_toplevel(ext: Ext, fork: Fork, monitor: number, smart_gaps: boolean) {
-        let rect = ext.monitor_work_area(monitor);
+        let rect = ext.monitor_work_area(monitor, fork.workspace);
 
         fork.smart_gapped = smart_gaps && fork.right === null;
 
@@ -121,7 +121,7 @@ export class AutoTiler {
 
     /** Attaches `win` to an optionally-given monitor */
     attach_to_monitor(ext: Ext, win: ShellWindow, workspace_id: [number, number], smart_gaps: boolean) {
-        let rect = ext.monitor_work_area(workspace_id[0]);
+        let rect = ext.monitor_work_area(workspace_id[0], workspace_id[1]);
 
         if (!smart_gaps) {
             rect.x += ext.gap_outer;
@@ -148,7 +148,7 @@ export class AutoTiler {
             if (monitor) {
                 if (fork.is_toplevel && fork.smart_gapped && fork.right) {
                     fork.smart_gapped = false;
-                    let rect = ext.monitor_work_area(fork.monitor);
+                    let rect = ext.monitor_work_area(fork.monitor, fork.workspace);
 
                     rect.x += ext.gap_outer;
                     rect.y += ext.gap_outer;
@@ -239,7 +239,7 @@ export class AutoTiler {
             if (reflow_fork) {
                 const fork = reflow_fork[1];
                 if (fork.is_toplevel && ext.settings.smart_gaps() && fork.right === null) {
-                    let rect = ext.monitor_work_area(fork.monitor);
+                    let rect = ext.monitor_work_area(fork.monitor, fork.workspace);
                     fork.set_area(rect);
                     fork.smart_gapped = true;
                 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -734,10 +734,11 @@ export class Ext extends Ecs.System<ExtEvent> {
         this.row_size = this.settings.row_size() * this.dpi;
     }
 
-    monitor_work_area(monitor: number): Rectangle {
-        const meta = wom
-            .get_active_workspace()
-            .get_work_area_for_monitor(monitor);
+    monitor_work_area(monitor: number, workspace_idx?: number): Rectangle {
+        const ws = workspace_idx !== undefined && workspace_idx !== null
+            ? wom.get_workspace_by_index(workspace_idx) ?? wom.get_active_workspace()
+            : wom.get_active_workspace();
+        const meta = ws.get_work_area_for_monitor(monitor);
 
         return Rect.Rectangle.from_meta(meta as Rectangular);
     }
@@ -2349,7 +2350,7 @@ export class Ext extends Ecs.System<ExtEvent> {
             for (const f of this.auto_tiler.forest.forks.values()) {
                 if (!f.is_toplevel) continue
 
-                const display = this.monitor_work_area(f.monitor)
+                const display = this.monitor_work_area(f.monitor, f.workspace)
 
                 if (display) {
                     const area = new Rect.Rectangle([display.x, display.y, display.width, display.height])

--- a/src/tiling.ts
+++ b/src/tiling.ts
@@ -235,7 +235,7 @@ export class Tiler {
 
         if (fork.is_toplevel && fork.smart_gapped) {
             fork.smart_gapped = false;
-            let rect = ext.monitor_work_area(fork.monitor);
+            let rect = ext.monitor_work_area(fork.monitor, fork.workspace);
 
             rect.x += ext.gap_outer;
             rect.y += ext.gap_outer;
@@ -317,7 +317,7 @@ export class Tiler {
 
         if (fork.is_toplevel && fork.smart_gapped) {
             fork.smart_gapped = false;
-            let rect = ext.monitor_work_area(fork.monitor);
+            let rect = ext.monitor_work_area(fork.monitor, fork.workspace);
 
             rect.x += ext.gap_outer;
             rect.y += ext.gap_outer;
@@ -451,7 +451,7 @@ export class Tiler {
         if (this.window) {
             const monitor_id = ext.monitors.get(this.window);
             if (monitor_id) {
-                const monitor = ext.monitor_work_area(monitor_id[0]);
+                const monitor = ext.monitor_work_area(monitor_id[0], monitor_id[1]);
                 let rect = this.rect(ext, monitor);
 
                 if (rect) {


### PR DESCRIPTION
## Summary

`monitor_work_area()` always queries the active workspace for work area geometry, even when tiling a window that just moved to a different workspace. When a window gets moved between workspaces, the workspace-changed signal fires and pop-shell detaches + reattaches the window to the new workspace's tiling tree. During that reattach, it calls `monitor_work_area()` to figure out where to place the window — but since the active workspace hasn't switched yet, `get_work_area_for_monitor()` returns geometry for the wrong workspace. Depending on timing, this can return `y=0` instead of `y=panel_height`, so the window gets tiled behind the top bar.

The fix adds an optional `workspace_idx` parameter to `monitor_work_area()` so callers that know which workspace they're targeting can pass it explicitly instead of relying on the active workspace. All tiling codepaths that have fork/workspace context (`attach_to_monitor`, `update_toplevel`, `detach_window`, smart gap recalculations) now pass the actual workspace index. Callers that genuinely operate on the active workspace (launcher, snap, display readiness check) are left unchanged.

This also explains why the bug is intermittent — it depends on whether GNOME has finished switching the active workspace by the time the tiling code runs.

Rebased on `master_jammy` per feedback on #1809.

Fixes #1565