### PR TITLE
fix: activate stacked windows without redundant raising

### DIFF
--- a/src/stack.ts
+++ b/src/stack.ts
@@ -212,10 +212,11 @@ export class Stack {
 
         if (this.widgets) this.widgets.tabs.visible = permitted;
 
-        this.reset_visibility(permitted);
-
         const win = this.ext.windows.get(entity);
-        if (!win) return;
+        if (!win) {
+            this.reset_visibility(permitted);
+            return;
+        }
 
         if (!Ecs.entity_eq(entity, this.active)) {
             this.prev_active = this.active;
@@ -662,20 +663,13 @@ export class Stack {
 
         // Connect tab-clicked signal
         c.button_signal = widget.connect('clicked', () => {
-            this.activate(entity);
             this.window_exec(comp, entity, (window) => {
                 const actor = window.meta.get_compositor_private();
                 if (actor) {
                     actor.show();
                     window.activate(false);
-
+                    this.activate(entity);
                     this.reposition();
-
-                    for (const comp of this.tabs) {
-                        this.buttons.get(comp.button)?.set_style_class_name(INACTIVE_TAB);
-                    }
-
-                    widget.set_style_class_name(ACTIVE_TAB);
                 }
             });
         });

--- a/src/window.ts
+++ b/src/window.ts
@@ -705,7 +705,6 @@ export function activate(ext: Ext, move_mouse: boolean, win: Meta.Window) {
 
         win.unminimize();
         workspace.activate_with_focus(win, global.get_current_time());
-        win.raise();
 
         const pointer_placement_permitted =
             move_mouse &&


### PR DESCRIPTION
## Summary

- Show and focus a stacked window before updating Pop Shell's active-tab state.
- Let `Stack.activate()` own tab visibility and styling updates.
- Remove the redundant `Meta.Window.raise()` after `activate_with_focus()`.

## Root cause

The tab click handler changed Pop Shell's active-window state and hid the previous actor before confirming that the selected window actor could be activated. It then explicitly raised a window that Mutter had already focused. This could leave compositor stacking and Pop Shell's stack state temporarily out of sync, producing `meta_window_set_stack_position_no_sync` assertions and unreliable tab activation.

## Impact

Stack tab clicks now follow one activation sequence and avoid the redundant stacking operation.

This is independent of #1824, which prevents DING's desktop surface from entering the normal window/focus path. It was field-tested in a Wayland session that also contained #1824.

## Testing

- `make compile`
- Logged out and back in on Ubuntu with GNOME 50.
- Repeatedly activated windows through Pop Shell stack tabs during normal use.
