### PR TITLE
fix: ignore no-op stack resize grabs

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1157,6 +1157,12 @@ export class Ext extends Ecs.System<ExtEvent> {
                     const forest = this.auto_tiler.forest;
                     const fork = forest.forks.get(fork_entity);
                     if (fork) {
+                        const movement = grab_op.operation(crect);
+
+                        // A click on a resize edge can begin and end a grab without
+                        // changing the window. Do not turn that into a tree resize.
+                        if (movement === Movement.NONE) return;
+
                         if (win.stack) {
                             const tab_dimension = this.dpi * stack.TAB_HEIGHT;
                             crect.height += tab_dimension;
@@ -1167,8 +1173,6 @@ export class Ext extends Ecs.System<ExtEvent> {
                         if (top_level) {
                             crect.clamp((forest.forks.get(top_level) as Fork).area);
                         }
-
-                        const movement = grab_op.operation(crect);
 
                         if (this.movement_is_valid(win, movement)) {
                             forest.resize(this, fork_entity, fork, win.entity, movement, crect);

--- a/src/movement.ts
+++ b/src/movement.ts
@@ -15,7 +15,7 @@ export function calculate(from: Rectangular, change: Rectangular): Movement {
 
     if (xpos && ypos) {
         if (from.width == change.width) {
-            if (from.height == change.width) {
+            if (from.height == change.height) {
                 return Movement.NONE;
             } else if (from.height < change.height) {
                 return Movement.GROW | Movement.DOWN;


### PR DESCRIPTION
## Summary

- Calculate resize movement from the window frame before adding stack-tab geometry.
- Correct the unchanged-height comparison in `Movement.calculate()`.
- Stop a zero-motion resize grab before it can change tiling-tree ratios.

## Root cause

Pop Shell records the raw window frame when a resize grab begins. For stacked windows, the grab-end path added the tab strip to the ending rectangle before comparing it with that raw starting frame. An edge click with no actual resize therefore appeared to be an upward grow operation.

The no-movement branch also compared the starting height with the ending width. Even when `Movement.NONE` was returned, it was accepted as valid and reached `forest.resize()`, where it followed the grow path.

## Impact

Clicking a stack's resize edge without dragging no longer shrinks the stack or reflows neighboring tiled windows. Actual directional resize operations retain their existing behavior.

This resize-grab path is independent of #1824's DING desktop-window detection and focus handling.

## Testing

- `make compile`
- Focused `Movement.calculate()` checks for unchanged, upward-grow, and downward-grow rectangles.
- Logged out and back in on Ubuntu with GNOME 50 and exercised the stack layout during normal use.
