### PR TITLE
fix: unstack window from multi-window stack with Super+S

### DIFF
--- a/src/auto_tiler.ts
+++ b/src/auto_tiler.ts
@@ -560,14 +560,56 @@ export class AutoTiler {
     }
 
     unstack(ext: Ext, fork: Fork, win: ShellWindow, toggled: boolean = false) {
-        const stack_toggle = (fork: Fork, branch: node.Node) => {
-            // If the stack contains 1 item, unstack it
+        const stack_toggle = (fork: Fork, branch: node.Node, is_left: boolean) => {
             const stack = branch.inner as node.NodeStack;
             if (stack.entities.length === 1) {
                 win.stack = null;
                 this.forest.stacks.remove(stack.idx)?.destroy();
                 fork.measure(this.forest, ext, fork.area, this.forest.on_record());
                 return node.Node.window(win.entity);
+            }
+
+            const container = this.forest.stacks.get(stack.idx);
+            if (!container) return null;
+
+            container.deactivate(win);
+
+            if (node.stack_remove(this.forest, stack, win.entity) === null) return null;
+            win.stack = null;
+            win.smart_gapped = false;
+
+            if (container.workspace === ext.active_workspace()) {
+                win.meta.get_compositor_private()?.show();
+            }
+
+            const win_node = node.Node.window(win.entity);
+
+            if (!fork.right) {
+                fork.right = win_node;
+                fork.set_ratio(fork.length() / 2);
+                fork.rebalance_orientation();
+                if (fork.is_toplevel && fork.smart_gapped) {
+                    fork.smart_gapped = false;
+                    for (const e of stack.entities) {
+                        ext.windows.with(e, (w) => { w.smart_gapped = false; });
+                    }
+                    this.update_toplevel(ext, fork, fork.monitor, ext.settings.smart_gaps());
+                }
+                this.forest.on_attach(fork.entity, win.entity);
+            } else {
+                const area = is_left ? fork.area_of_left(ext) : fork.area_of_right(ext);
+                const [left_child, right_child] = is_left ? [win_node, branch] : [branch, win_node];
+                const [new_fork_entity] = this.forest.create_fork(left_child, right_child, area, fork.workspace, fork.monitor);
+                if (is_left) {
+                    fork.left = node.Node.fork(new_fork_entity);
+                } else {
+                    fork.right = node.Node.fork(new_fork_entity);
+                }
+                this.forest.parents.insert(new_fork_entity, fork.entity);
+                this.forest.on_attach(new_fork_entity, win.entity);
+                for (const e of stack.entities) {
+                    this.forest.on_attach(new_fork_entity, e);
+                }
             }
 
             return null;
@@ -579,12 +621,11 @@ export class AutoTiler {
             fork.left = node.Node.stacked(win.entity, win.stack);
             fork.measure(this.forest, ext, fork.area, this.forest.on_record());
         } else if (fork.left.is_in_stack(win.entity)) {
-            const node = stack_toggle(fork, fork.left);
-            if (node) {
-                fork.left = node;
-
+            const n = stack_toggle(fork, fork.left, true);
+            if (n) {
+                fork.left = n;
                 if (!fork.right) {
-                    this.forest.reassign_to_parent(fork, node);
+                    this.forest.reassign_to_parent(fork, n);
                 }
             }
         } else if (toggled && fork.right?.is_window(win.entity)) {
@@ -593,8 +634,8 @@ export class AutoTiler {
             fork.right = node.Node.stacked(win.entity, win.stack);
             fork.measure(this.forest, ext, fork.area, this.forest.on_record());
         } else if (fork.right?.is_in_stack(win.entity)) {
-            const node = stack_toggle(fork, fork.right);
-            if (node) fork.right = node;
+            const n = stack_toggle(fork, fork.right, false);
+            if (n) fork.right = n;
         }
 
         this.tile(ext, fork, fork.area);


### PR DESCRIPTION
## Background

Pop Shell supports window stacking, where multiple windows can be grouped
into a tabbed stack node in the tiling tree. The shortcut Super+S
(toggle-stacking) is intended to move the focused window in or out of a stack.

When a stack contained only one window, Super+S correctly unstacked it.
However, when a stack contained more than one window, pressing Super+S had
no effect — the multi-window path in `unstack()` / `stack_toggle()` had no
implementation and fell through silently.

## Fix

When the focused window is in a stack with other windows:

1. Call `container.deactivate()` on the focused window to avoid signal leaks.
2. Remove the window from the stack with `stack_remove()`.
3. Restore the window's compositor visibility if on the active workspace
   (non-active tabs are hidden via `actor.hide()` by `Stack.activate()`).
4. Place the removed window as a split tile alongside the remaining stack:
   - If the fork has no right branch yet, assign the window there directly.
   - Otherwise, create a new inner fork containing the window and the
     remaining stack, and rewire the parent fork's branch to point to it.
5. Update `parents`, `attached`, and `smart_gapped` accordingly.

## Verified on

- Ubuntu 24.04.4 LTS (Noble Numbat)
- GNOME Shell 46.0